### PR TITLE
chore: Rename binary and cmd directory from monarch-sync to itemize

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,13 +112,13 @@ jobs:
           GOOS: ${{ matrix.os == 'ubuntu-latest' && 'linux' || matrix.os == 'macos-latest' && 'darwin' || 'windows' }}
           GOARCH: ${{ matrix.arch }}
         run: |
-          go build -v -o monarchmoney-sync-backend${{ matrix.os == 'windows-latest' && '.exe' || '' }} ./cmd/monarch-sync/
+          go build -v -o itemize${{ matrix.os == 'windows-latest' && '.exe' || '' }} ./cmd/itemize/
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: binary-${{ matrix.os }}-${{ matrix.arch }}
-          path: monarchmoney-sync-backend*
+          path: itemize*
 
   security:
     name: Security Scan

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,28 +7,28 @@
 
 A CLI application that syncs Walmart, Costco, and Amazon purchases with Monarch Money, automatically categorizing items and splitting transactions. It includes:
 - **CLI tool** for command-line syncing
-- **API server** (`./monarch-sync serve`) for programmatic access
+- **API server** (`./itemize serve`) for programmatic access
 
 ## Quick Reference
 
 ### Build and Run
 ```bash
 # Build Go backend
-go build -o monarch-sync ./cmd/monarch-sync/
+go build -o itemize ./cmd/itemize/
 
 # Run with dry-run (preview, no changes)
-./monarch-sync walmart -dry-run -days 14 -verbose
-./monarch-sync costco -dry-run -days 7
+./itemize walmart -dry-run -days 14 -verbose
+./itemize costco -dry-run -days 7
 
 # Apply changes
-./monarch-sync walmart -days 14
-./monarch-sync costco -days 7 -max 10
+./itemize walmart -days 14
+./itemize costco -days 7 -max 10
 
 # Force reprocess already-processed orders
-./monarch-sync walmart -force
+./itemize walmart -force
 
 # Start API server
-./monarch-sync serve -port 8085
+./itemize serve -port 8085
 ```
 
 ### Test
@@ -230,7 +230,7 @@ This gives us clean code with proper level-based filtering instead of scattered 
 ## File Organization
 
 ### Where Things Live
-- **Entry point:** [cmd/monarch-sync/main.go](cmd/monarch-sync/main.go)
+- **Entry point:** [cmd/itemize/main.go](cmd/itemize/main.go)
 - **Business logic:** `internal/domain/`
 - **Workflow coordination:** `internal/application/sync/`
 - **External APIs:** `internal/adapters/`
@@ -388,7 +388,7 @@ See [internal/infrastructure/storage/sqlite.go](internal/infrastructure/storage/
 ## Project Scope
 
 - ✅ **CLI tool** - Primary command-line interface
-- ✅ **API server** - HTTP endpoints for programmatic access (`./monarch-sync serve`)
+- ✅ **API server** - HTTP endpoints for programmatic access (`./itemize serve`)
 - ❌ **NOT a Chrome extension** - Direct provider API integration
 - ❌ **NOT a SaaS** - Local deployment only
 - ❌ **NOT real-time** - Manual runs or scheduled via cron

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Variables
-BINARY_NAME=monarch-sync
+BINARY_NAME=itemize
 GO_FILES=$(shell find . -name '*.go' -type f -not -path "./vendor/*")
 COVERAGE_FILE=coverage.out
 COVERAGE_HTML=coverage.html
@@ -33,7 +33,7 @@ all: pre-commit build
 ## build: Build the CLI binary
 build:
 	@echo "$(GREEN)Building $(BINARY_NAME)...$(NC)"
-	$(GOBUILD) -v -o $(BINARY_NAME) ./cmd/monarch-sync
+	$(GOBUILD) -v -o $(BINARY_NAME) ./cmd/itemize
 	@echo "$(GREEN)Build complete!$(NC)"
 
 ## clean: Remove build artifacts and temporary files
@@ -96,11 +96,11 @@ pre-commit: fmt vet test
 release:
 	@echo "$(GREEN)Building release binaries...$(NC)"
 	@mkdir -p dist
-	GOOS=darwin GOARCH=amd64 $(GOBUILD) -o dist/$(BINARY_NAME)-darwin-amd64 ./cmd/monarch-sync
-	GOOS=darwin GOARCH=arm64 $(GOBUILD) -o dist/$(BINARY_NAME)-darwin-arm64 ./cmd/monarch-sync
-	GOOS=linux GOARCH=amd64 $(GOBUILD) -o dist/$(BINARY_NAME)-linux-amd64 ./cmd/monarch-sync
-	GOOS=linux GOARCH=arm64 $(GOBUILD) -o dist/$(BINARY_NAME)-linux-arm64 ./cmd/monarch-sync
-	GOOS=windows GOARCH=amd64 $(GOBUILD) -o dist/$(BINARY_NAME)-windows-amd64.exe ./cmd/monarch-sync
+	GOOS=darwin GOARCH=amd64 $(GOBUILD) -o dist/$(BINARY_NAME)-darwin-amd64 ./cmd/itemize
+	GOOS=darwin GOARCH=arm64 $(GOBUILD) -o dist/$(BINARY_NAME)-darwin-arm64 ./cmd/itemize
+	GOOS=linux GOARCH=amd64 $(GOBUILD) -o dist/$(BINARY_NAME)-linux-amd64 ./cmd/itemize
+	GOOS=linux GOARCH=arm64 $(GOBUILD) -o dist/$(BINARY_NAME)-linux-arm64 ./cmd/itemize
+	GOOS=windows GOARCH=amd64 $(GOBUILD) -o dist/$(BINARY_NAME)-windows-amd64.exe ./cmd/itemize
 	@echo "$(GREEN)Release binaries built in dist/$(NC)"
 
 ## version: Display version information
@@ -114,7 +114,7 @@ version:
 ## run-costco: Run Costco sync in dry-run mode (safe testing)
 run-costco:
 	@echo "$(GREEN)Running Costco sync (dry-run)...$(NC)"
-	$(GOCMD) run ./cmd/monarch-sync costco -dry-run -verbose
+	$(GOCMD) run ./cmd/itemize costco -dry-run -verbose
 
 ## install-tools: Install development tools (goimports)
 install-tools:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Monarch Money Sync
+# Itemize
 
 CLI tool that syncs purchases from Walmart, Costco, and Amazon with Monarch Money. Automatically splits transactions by category using AI.
 
@@ -28,7 +28,7 @@ CLI tool that syncs purchases from Walmart, Costco, and Amazon with Monarch Mone
 ```bash
 git clone https://github.com/eshaffer321/itemize
 cd itemize
-go build -o monarch-sync ./cmd/monarch-sync/
+go build -o itemize ./cmd/itemize/
 ```
 
 ### Configure
@@ -56,14 +56,14 @@ storage:
 
 ```bash
 # Preview changes (dry run)
-./monarch-sync walmart -dry-run -days 14
-./monarch-sync costco -dry-run -days 7
-./monarch-sync amazon -dry-run -days 7
+./itemize walmart -dry-run -days 14
+./itemize costco -dry-run -days 7
+./itemize amazon -dry-run -days 7
 
 # Apply changes
-./monarch-sync walmart -days 14
-./monarch-sync costco -days 7
-./monarch-sync amazon -days 7
+./itemize walmart -days 14
+./itemize costco -days 7
+./itemize amazon -days 7
 ```
 
 ### Flags

--- a/cmd/itemize/main.go
+++ b/cmd/itemize/main.go
@@ -106,7 +106,7 @@ func main() {
 }
 
 func printUsage() {
-	fmt.Println("Usage: monarch-sync <command> [flags]")
+	fmt.Println("Usage: itemize <command> [flags]")
 	fmt.Println()
 	fmt.Println("Commands:")
 	fmt.Println("  serve       Start the API server")

--- a/docs/LOGGER_ROLLOUT.md
+++ b/docs/LOGGER_ROLLOUT.md
@@ -104,7 +104,7 @@ go mod tidy
 Once all three projects are updated, you'll see consistent logging:
 
 ```
-monarch-sync: Costco (PRODUCTION mode)
+itemize: Costco (PRODUCTION mode)
 Database: monarch_sync.db
 Provider: Costco | Lookback: 17 days
 
@@ -162,10 +162,10 @@ After updating each library:
 After integrating in monarchmoney-sync-backend:
 
 - [ ] Build succeeds
-- [ ] `./monarch-sync costco -dry-run -days 7 -verbose` shows consistent logs
-- [ ] `./monarch-sync walmart -dry-run -days 7 -verbose` shows consistent logs
+- [ ] `./itemize costco -dry-run -days 7 -verbose` shows consistent logs
+- [ ] `./itemize walmart -dry-run -days 7 -verbose` shows consistent logs
 - [ ] Colors appear in terminal
-- [ ] No colors when piping: `./monarch-sync costco -verbose 2>&1 | cat`
+- [ ] No colors when piping: `./itemize costco -verbose 2>&1 | cat`
 
 ## Documentation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -254,7 +254,7 @@ This provides flexibility without full hexagonal overhead.
 - Created `internal/adapters/` for external integrations
 - Moved `internal/providers/` → `internal/adapters/providers/`
 - Moved `internal/clients/` → `internal/adapters/clients/`
-- Moved CLI from `cmd/monarch-sync/cli/` → `internal/cli/`
+- Moved CLI from `cmd/itemize/cli/` → `internal/cli/`
 
 **Key Improvements:**
 - Fixed broken module paths and imports

--- a/docs/deduplication-safety.md
+++ b/docs/deduplication-safety.md
@@ -106,7 +106,7 @@ Only `success` status prevents reprocessing:
 The `--force` flag **bypasses Layer 1 only**:
 
 ```bash
-./monarch-sync walmart sync --force
+./itemize walmart sync --force
 ```
 
 **What it does:**
@@ -204,10 +204,10 @@ WHERE provider = 'unknown' AND status = 'success';
 ### Test 1: Database Protection
 ```bash
 # Process an order
-./monarch-sync walmart sync --dry-run=false
+./itemize walmart sync --dry-run=false
 
 # Try again (should skip)
-./monarch-sync walmart sync --dry-run=false
+./itemize walmart sync --dry-run=false
 # Output: "Skipping already processed order"
 ```
 
@@ -217,14 +217,14 @@ WHERE provider = 'unknown' AND status = 'success';
 rm monarch_sync.db
 
 # Re-run sync
-./monarch-sync walmart sync --dry-run=false
+./itemize walmart sync --dry-run=false
 # Output: "Transaction already has splits" (Layer 2 kicks in)
 ```
 
 ### Test 3: Force Flag
 ```bash
 # Force reprocess
-./monarch-sync walmart sync --force
+./itemize walmart sync --force
 # Output: "Transaction already has splits" (Layer 2 still protects)
 ```
 

--- a/docs/design-migrations.md
+++ b/docs/design-migrations.md
@@ -361,7 +361,7 @@ func NewStorage(dbPath string) (*Storage, error) {
 
 ```bash
 rm monarch_sync.db
-./monarch-sync walmart -dry-run -days 7
+./itemize walmart -dry-run -days 7
 sqlite3 monarch_sync.db "SELECT * FROM schema_migrations"
 # Should show: 1, 2, 3
 ```
@@ -370,7 +370,7 @@ sqlite3 monarch_sync.db "SELECT * FROM schema_migrations"
 
 ```bash
 # Use existing monarch_sync.db
-./monarch-sync walmart -dry-run -days 7
+./itemize walmart -dry-run -days 7
 sqlite3 monarch_sync.db "SELECT * FROM schema_migrations"
 # Should show: 1, 2, 3
 # processing_records should be unchanged
@@ -381,7 +381,7 @@ sqlite3 monarch_sync.db "SELECT * FROM schema_migrations"
 ```bash
 # Manually create schema_migrations and add version 1 and 2
 sqlite3 monarch_sync.db "INSERT INTO schema_migrations (version, name) VALUES (1, 'initial'), (2, 'sync_runs')"
-./monarch-sync walmart -dry-run -days 7
+./itemize walmart -dry-run -days 7
 sqlite3 monarch_sync.db "SELECT * FROM schema_migrations"
 # Should show: 1, 2, 3 (only ran migration 3)
 ```

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -141,13 +141,13 @@ Use the `-verbose` flag to see detailed logs:
 
 ```bash
 # Minimal output
-./monarch-sync costco -days 14
+./itemize costco -days 14
 
 # Verbose output (shows all INFO logs)
-./monarch-sync costco -days 14 -verbose
+./itemize costco -days 14 -verbose
 
 # Debug output (shows DEBUG logs too)
-LOG_LEVEL=debug ./monarch-sync costco -days 14 -verbose
+LOG_LEVEL=debug ./itemize costco -days 14 -verbose
 ```
 
 ## Implementation Details

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -14,7 +14,7 @@ func PrintHeader(providerName string, dryRun bool) {
 	if dryRun {
 		mode = "DRY-RUN"
 	}
-	fmt.Printf("monarch-sync: %s (%s mode)\n", providerName, mode)
+	fmt.Printf("itemize: %s (%s mode)\n", providerName, mode)
 }
 
 // PrintConfiguration prints sync configuration


### PR DESCRIPTION
## Summary

- Rename `cmd/monarch-sync/` → `cmd/itemize/`
- Update binary name (`BINARY_NAME=itemize`) in Makefile, Dockerfile, and CI workflows
- Update usage strings in `main.go` (`Usage: itemize <command>`) and `cli/output.go`
- Update all `./monarch-sync` references in README.md, CLAUDE.md, and all docs

## Test plan

- [x] `go build -o itemize ./cmd/itemize/` builds successfully
- [x] All Go tests pass (`go test ./...`)
- [x] No remaining `monarch-sync` references in source files, docs, or CI configs