### PR TITLE
chore: ignore root itemize binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ go.work
 Thumbs.db
 
 # Build artifacts
+/itemize
 monarchmoney-sync-backend
 walmart-monarch-backend
 main


### PR DESCRIPTION
Adds `/itemize` to `.gitignore` so the locally built CLI in the repo root is not accidentally committed.

The binary is produced by `make build` or `go build -o itemize ./cmd/itemize/`.

Made with [Cursor](https://cursor.com)