### PR TITLE
fix: apply Costco discounts referenced by description instead of item number

### DIFF
--- a/docs/bug-fixes.md
+++ b/docs/bug-fixes.md
@@ -12,6 +12,32 @@ Each bug fix entry should include:
 
 ## Bug Fixes
 
+### 2026-05-24: Costco discount applied by description instead of item number
+
+**Description:**
+Some Costco receipt line items reference their parent via description (e.g. `/AAA BATTERY`) rather than item number (e.g. `/1234567`). The discount lookup only checked the item-number map, so these discounts were logged as "orphaned" and silently dropped, leaving the item price too high.
+
+**Test Case:**
+```go
+// provider_test.go: "discount references parent by description instead of item number"
+// Discount item has ItemDescription01 = "/AAA BATTERY"; parent has ItemNumber "379938"
+// Expected: discount of -$2.50 applied → price $12.49
+// Actual before fix: price remained $14.99, WARN logged
+```
+
+**Root Cause:**
+`convertReceipt` built a single `itemMap` keyed by `ItemNumber`. `GetParentItemNumber()` strips the leading `/`, returning `"AAA BATTERY"` — a string that never matches a numeric key.
+
+**Fix Applied:**
+Added a parallel `descMap` keyed by uppercased `ItemDescription01`. When the item-number lookup misses, fall back to the description map before declaring the discount orphaned.
+
+**Verification:**
+- New test `discount references parent by description instead of item number` passes.
+- All existing discount-netting tests continue to pass.
+- `go test ./... -race` green.
+
+---
+
 ### 2025-09-01: No bugs discovered yet
 The project was developed using strict TDD methodology from the start, preventing bugs through test-first development.
 

--- a/internal/adapters/providers/costco/provider.go
+++ b/internal/adapters/providers/costco/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	costcogo "github.com/eshaffer321/costco-go/pkg/costco"
@@ -244,13 +245,14 @@ func (p *Provider) convertReceipt(receipt *costcogo.Receipt, hasDetails bool) pr
 
 	var items []providers.OrderItem
 	if hasDetails {
-		// Build a map to net out discount line items
+		// Build maps to net out discount line items
 		itemMap := make(map[string]*CostcoOrderItem)
+		descMap := make(map[string]*CostcoOrderItem) // fallback: keyed by uppercased description
 
 		// First pass: collect all non-discount items
 		for _, item := range receipt.ItemArray {
 			if !item.IsDiscount() {
-				itemMap[item.ItemNumber] = &CostcoOrderItem{
+				entry := &CostcoOrderItem{
 					name:        item.ItemDescription01,
 					price:       item.Amount,
 					quantity:    float64(item.Unit),
@@ -258,21 +260,27 @@ func (p *Provider) convertReceipt(receipt *costcogo.Receipt, hasDetails bool) pr
 					sku:         item.ItemNumber,
 					description: fmt.Sprintf("%s %s", item.ItemDescription01, item.ItemDescription02),
 				}
+				itemMap[item.ItemNumber] = entry
+				descMap[strings.ToUpper(strings.TrimSpace(item.ItemDescription01))] = entry
 			}
 		}
 
 		// Second pass: apply discounts to parent items
 		for _, item := range receipt.ItemArray {
 			if item.IsDiscount() {
-				parentNum := item.GetParentItemNumber()
-				if parentItem, exists := itemMap[parentNum]; exists {
-					// Apply discount (item.Amount is already negative)
+				parentRef := item.GetParentItemNumber()
+				parentItem, exists := itemMap[parentRef]
+				if !exists {
+					// Costco sometimes references the parent by description (e.g. "/AAA BATTERY")
+					// rather than by item number (e.g. "/1234567").
+					parentItem, exists = descMap[strings.ToUpper(parentRef)]
+				}
+				if exists {
 					parentItem.price += item.Amount
 				} else {
-					// Orphaned discount - log warning and skip
 					p.logger.Warn("found orphaned discount with no matching parent item",
 						"discount_item", item.ItemNumber,
-						"parent_item_ref", parentNum,
+						"parent_item_ref", parentRef,
 						"discount_amount", item.Amount,
 					)
 				}

--- a/internal/adapters/providers/costco/provider_test.go
+++ b/internal/adapters/providers/costco/provider_test.go
@@ -467,4 +467,37 @@ func TestConvertReceipt_DiscountNetting(t *testing.T) {
 		assert.Equal(t, 4.99, itemMap["ROTISSERIE CHICKEN"].GetPrice(), "Chicken at full price")
 		assert.Equal(t, 23.00, itemMap["TOILET PAPER"].GetPrice(), "TP at full price")
 	})
+
+	t.Run("discount references parent by description instead of item number", func(t *testing.T) {
+		// Costco sometimes emits discount lines like "/AAA BATTERY" (description)
+		// rather than "/1234567" (item number). The discount should still be applied.
+		receipt := &costcogo.Receipt{
+			TransactionBarcode: "TEST505",
+			TransactionDate:    "2025-10-20",
+			Total:              12.49,
+			SubTotal:           12.49,
+			Taxes:              0.00,
+			ItemArray: []costcogo.ReceiptItem{
+				{
+					ItemNumber:        "379938",
+					ItemDescription01: "AAA BATTERY",
+					Amount:            14.99,
+					Unit:              1,
+				},
+				{
+					ItemNumber:        "999001",
+					ItemDescription01: "/AAA BATTERY", // description ref, not item number
+					Amount:            -2.50,
+					Unit:              -1,
+				},
+			},
+		}
+
+		order := provider.convertReceipt(receipt, true)
+		items := order.GetItems()
+
+		require.Len(t, items, 1, "Should have 1 item after netting description-referenced discount")
+		assert.Equal(t, "AAA BATTERY", items[0].GetName())
+		assert.Equal(t, 12.49, items[0].GetPrice(), "Discount should be applied via description fallback")
+	})
 }


### PR DESCRIPTION
## Summary
- Costco sometimes references a discount's parent item by description (e.g. `/AAA BATTERY`) rather than by item number (e.g. `/1234567`)
- Previously these were logged as orphaned and the -$2.50 discount was dropped, leaving the item at full price
- Fix adds a `descMap` keyed by uppercased description as a fallback when the item-number lookup misses

## Test plan
- [x] New test: `discount references parent by description instead of item number` — red before fix, green after
- [x] All existing discount-netting tests still pass
- [x] `go test ./... -race` clean