### PR TITLE
chore: fix release workflow for renamed binary and removed Docker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
         run: |
-          go build -v -ldflags="-s -w -X main.version=${{ github.ref_name }}" -o monarchmoney-sync-backend${{ matrix.suffix }} .
+          go build -v -ldflags="-s -w -X main.version=${{ github.ref_name }}" -o itemize${{ matrix.suffix }} ./cmd/itemize/
 
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
@@ -95,56 +95,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
-          asset_path: ./monarchmoney-sync-backend${{ matrix.suffix }}
-          asset_name: monarchmoney-sync-backend${{ matrix.suffix }}
+          asset_path: ./itemize${{ matrix.suffix }}
+          asset_name: itemize${{ matrix.suffix }}
           asset_content_type: application/octet-stream
-
-  docker:
-    name: Build and Push Docker Image
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ${{ secrets.DOCKER_USERNAME }}/monarchmoney-sync-backend
-            ghcr.io/${{ github.repository }}
-          tags: |
-            type=ref,event=tag
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Build from `./cmd/itemize/` — entry point moved from repo root when binary was renamed in #16
- Output binary named `itemize` instead of `monarchmoney-sync-backend`
- Remove Docker job — Dockerfile was deleted in #18, causing the job to always fail

## Root cause
The release workflow wasn't updated alongside the renames in #16 and #18, so `v0.1.0` failed with `no Go files in /home/runner/work/itemize/itemize`.