### PR TITLE
fix: bump costco-go to v0.3.10 (word-overlap discount matching)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/eshaffer321/monarchmoney-sync-backend
 go 1.25.10
 
 require (
-	github.com/eshaffer321/costco-go v0.3.9
+	github.com/eshaffer321/costco-go v0.3.10
 	github.com/eshaffer321/monarchmoney-go v1.0.5
 	github.com/eshaffer321/walmart-client-go/v2 v2.0.1
 	github.com/go-chi/chi/v5 v5.2.5

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/eshaffer321/costco-go v0.3.9 h1:HoRcJHMljCJY1DQECQ4hsM3hzAEAqfzX8CckEwNin9o=
-github.com/eshaffer321/costco-go v0.3.9/go.mod h1:ANJTHfRSPyot9cWKNlfs5qDKRKkA4tYORrorvWx/vbM=
+github.com/eshaffer321/costco-go v0.3.10 h1:Lp8ZUEuLQC3ciGHWWjiPxMOez+hJe9YZ2JmlHxeC/HI=
+github.com/eshaffer321/costco-go v0.3.10/go.mod h1:ANJTHfRSPyot9cWKNlfs5qDKRKkA4tYORrorvWx/vbM=
 github.com/eshaffer321/monarchmoney-go v1.0.5 h1:V3iP0bvB1q3+m9Gkl6KBCFL44sNsiHDbTxSOU9fHZco=
 github.com/eshaffer321/monarchmoney-go v1.0.5/go.mod h1:ZKPCYT7NcsKGI+YpJ2EqPtfE3dKfuPbiTUrj6J84ot4=
 github.com/eshaffer321/walmart-client-go/v2 v2.0.1 h1:R8NFqKqfdri02Jhmr6jOMpCLAzjdiRbStLtjGKo6WaA=


### PR DESCRIPTION
## Changes

Bumps `costco-go` from `v0.3.9` → `v0.3.10`.

### Why

After merging #23 (which introduced `NetDiscounts`), the orphaned-discount warning was still firing on real receipt `21134301000462605131128`:

```
[WARN] found orphaned discount with no matching parent item discount_item=379938 parent_item_ref=AAA BATTERY discount_amount=-2.5
```

A verbose debug dump of the raw receipt items revealed the actual data:

```
item_number=1627198  desc01="DURACELL AAA"   ← the actual product
item_number=379938   desc01="/AAA BATTERY"   ← the coupon
```

`"DURACELL AAA"` shares no substring with `"AAA BATTERY"`, so neither the exact-description nor the substring fallbacks in v0.3.9 could match them.

### Fix (in costco-go v0.3.10)

Added a 4th matching strategy — **word-overlap scoring** — that scores candidate items by how many significant words (≥3 chars) from the coupon reference appear in the item description, then picks the highest-scoring match. The shared token `AAA` (len=3) bridges `"DURACELL AAA"` and `"AAA BATTERY"`.

Also tightened the v0.3.9 substring reverse-contains guard (`len(desc) >= len(ref)/2`) to prevent short item descriptions from vacuously matching long coupon tokens.

## Checklist
- [x] Tests passing (`go test ./... -race`)
- [x] go.mod / go.sum updated