### PR TITLE
ci: bump Go to 1.25.11 to fix govulncheck stdlib advisories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main, develop ]
 
 env:
-  GO_VERSION: '1.25.10'
+  GO_VERSION: '1.25.11'
 
 jobs:
   lint:
@@ -72,7 +72,7 @@ jobs:
     needs: [module-integrity]
     strategy:
       matrix:
-        go-version: ['1.25.10']
+        go-version: ['1.25.11']
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -92,7 +92,7 @@ jobs:
           go tool cover -func=coverage.txt
 
       - name: Upload coverage reports to Codecov
-        if: matrix.go-version == '1.25.10'
+        if: matrix.go-version == '1.25.11'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.25.10'
+  GO_VERSION: '1.25.11'
 
 jobs:
   test:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/eshaffer321/monarchmoney-sync-backend
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/eshaffer321/costco-go v0.3.10


### PR DESCRIPTION
## Summary
`govulncheck` is failing on `main` (unrelated to #26 — it's a fresh Go security release). Two Go standard-library advisories, both fixed in **go1.25.11**:

| Advisory | Package | Fixed in |
|---|---|---|
| [GO-2026-5039](https://pkg.go.dev/vuln/GO-2026-5039) | net/textproto | go1.25.11 |
| [GO-2026-5037](https://pkg.go.dev/vuln/GO-2026-5037) | crypto/x509 | go1.25.11 |

## Changes
- `GO_VERSION` 1.25.10 → 1.25.11 in `ci.yml` and `release.yml`
- test matrix + codecov `if` bumped to 1.25.11
- `go.mod` `go` directive bumped to 1.25.11

## Verification
`govulncheck ./...` → **No vulnerabilities found.** locally on go1.25.11. Build + tests pass.