### PR TITLE
feat: make OpenAI categorization model configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ monarch:
 
 openai:
   api_key: "${OPENAI_API_KEY}"
-  model: "gpt-4o"
+  model: "gpt-5.4-nano"
 
 storage:
   database_path: "monarch_sync.db"

--- a/config.yaml
+++ b/config.yaml
@@ -35,7 +35,7 @@ monarch:
 # OpenAI configuration
 openai:
   api_key: "${OPENAI_API_KEY}"
-  model: "gpt-4o"
+  model: "gpt-5.4-nano"
 
 # Storage configuration
 storage:

--- a/internal/adapters/clients/clients.go
+++ b/internal/adapters/clients/clients.go
@@ -25,7 +25,7 @@ func NewClients(cfg *config.Config) (*Clients, error) {
 	// Initialize OpenAI client and cache for categorizer
 	openAIClient := categorizer.NewRealOpenAIClient(openAIKey)
 	cache := categorizer.NewMemoryCache()
-	cat := categorizer.NewCategorizer(openAIClient, cache)
+	cat := categorizer.NewCategorizer(openAIClient, cache, cfg.OpenAI.Model)
 
 	return &Clients{
 		Monarch:     mClient,

--- a/internal/domain/categorizer/categorizer.go
+++ b/internal/domain/categorizer/categorizer.go
@@ -37,10 +37,11 @@ type CategorizationResult struct {
 
 // OpenAI API types
 type ChatCompletionRequest struct {
-	Model          string          `json:"model"`
-	Messages       []Message       `json:"messages"`
-	Temperature    float64         `json:"temperature"`
-	ResponseFormat *ResponseFormat `json:"response_format,omitempty"`
+	Model           string          `json:"model"`
+	Messages        []Message       `json:"messages"`
+	Temperature     *float64        `json:"temperature,omitempty"`
+	ReasoningEffort *string         `json:"reasoning_effort,omitempty"`
+	ResponseFormat  *ResponseFormat `json:"response_format,omitempty"`
 }
 
 type ResponseFormat struct {
@@ -75,15 +76,23 @@ type Cache interface {
 type Categorizer struct {
 	client OpenAIClient
 	cache  Cache
+	Model  string
 }
 
 // NewCategorizer creates a new categorizer
-func NewCategorizer(client OpenAIClient, cache Cache) *Categorizer {
+func NewCategorizer(client OpenAIClient, cache Cache, model string) *Categorizer {
+	if strings.TrimSpace(model) == "" {
+		model = DefaultModel
+	}
+
 	return &Categorizer{
 		client: client,
 		cache:  cache,
+		Model:  model,
 	}
 }
+
+const DefaultModel = "gpt-5.4-nano"
 
 // CategorizeItems categorizes a list of items using available categories
 func (c *Categorizer) CategorizeItems(ctx context.Context, items []Item, categories []Category) (*CategorizationResult, error) {
@@ -147,9 +156,9 @@ func (c *Categorizer) CategorizeItems(ctx context.Context, items []Item, categor
 
 // Retry configuration
 const (
-	maxRetries    = 3
-	baseDelay     = 1 * time.Second
-	maxDelay      = 8 * time.Second
+	maxRetries = 3
+	baseDelay  = 1 * time.Second
+	maxDelay   = 8 * time.Second
 )
 
 // isRetryableError determines if an error is transient and worth retrying
@@ -177,8 +186,7 @@ func (c *Categorizer) callOpenAI(ctx context.Context, items []Item, categories [
 	prompt := c.buildPrompt(items, categories)
 
 	request := ChatCompletionRequest{
-		Model:       "gpt-4o", // Using GPT-4o for better performance and lower cost
-		Temperature: 0.1,      // Low temperature for consistent categorization
+		Model: c.Model,
 		ResponseFormat: &ResponseFormat{
 			Type: "json_object",
 		},
@@ -192,6 +200,13 @@ func (c *Categorizer) callOpenAI(ctx context.Context, items []Item, categories [
 				Content: prompt,
 			},
 		},
+	}
+	if isGPT5Model(c.Model) {
+		reasoningEffort := "low"
+		request.ReasoningEffort = &reasoningEffort
+	} else {
+		temperature := 0.1
+		request.Temperature = &temperature
 	}
 
 	var lastErr error
@@ -225,6 +240,10 @@ func (c *Categorizer) callOpenAI(ctx context.Context, items []Item, categories [
 	}
 
 	return nil, fmt.Errorf("%w after %d attempts", lastErr, maxRetries)
+}
+
+func isGPT5Model(model string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(model)), "gpt-5")
 }
 
 // buildPrompt creates the prompt for OpenAI

--- a/internal/domain/categorizer/categorizer_test.go
+++ b/internal/domain/categorizer/categorizer_test.go
@@ -43,7 +43,7 @@ func TestCategorizer_CategorizeItems_Success(t *testing.T) {
 	mockClient := new(MockOpenAIClient)
 	mockCache := new(MockCache)
 
-	categorizer := NewCategorizer(mockClient, mockCache)
+	categorizer := NewCategorizer(mockClient, mockCache, "gpt-4o-mini")
 
 	// Test data
 	items := []Item{
@@ -77,8 +77,11 @@ func TestCategorizer_CategorizeItems_Success(t *testing.T) {
 
 	// Mock OpenAI call
 	mockClient.On("CreateChatCompletion", ctx, mock.MatchedBy(func(req ChatCompletionRequest) bool {
-		// Verify the request contains the right model and has a system message
-		return req.Model == "gpt-4o" &&
+		// Verify the request contains the configured model and has a system message
+		return req.Model == "gpt-4o-mini" &&
+			req.Temperature != nil &&
+			*req.Temperature == 0.1 &&
+			req.ReasoningEffort == nil &&
 			len(req.Messages) > 0 &&
 			req.ResponseFormat != nil &&
 			req.ResponseFormat.Type == "json_object"
@@ -119,7 +122,7 @@ func TestCategorizer_CategorizeItems_WithCache(t *testing.T) {
 	mockClient := new(MockOpenAIClient)
 	mockCache := new(MockCache)
 
-	categorizer := NewCategorizer(mockClient, mockCache)
+	categorizer := NewCategorizer(mockClient, mockCache, "")
 
 	// Test data
 	items := []Item{
@@ -160,7 +163,7 @@ func TestCategorizer_CategorizeItems_PartialCache(t *testing.T) {
 	mockClient := new(MockOpenAIClient)
 	mockCache := new(MockCache)
 
-	categorizer := NewCategorizer(mockClient, mockCache)
+	categorizer := NewCategorizer(mockClient, mockCache, "gpt-5.4-nano")
 
 	// Test data
 	items := []Item{
@@ -188,8 +191,11 @@ func TestCategorizer_CategorizeItems_PartialCache(t *testing.T) {
 
 	// Mock OpenAI call for uncached item
 	mockClient.On("CreateChatCompletion", ctx, mock.MatchedBy(func(req ChatCompletionRequest) bool {
-		// Should only include uncached item
-		return req.Model == "gpt-4o"
+		// Should only include uncached item, and GPT-5-family models should omit temperature.
+		return req.Model == "gpt-5.4-nano" &&
+			req.Temperature == nil &&
+			req.ReasoningEffort != nil &&
+			*req.ReasoningEffort == "low"
 	})).Return(&ChatCompletionResponse{
 		Choices: []Choice{
 			{
@@ -229,7 +235,7 @@ func TestCategorizer_CategorizeItems_EmptyItems(t *testing.T) {
 	mockClient := new(MockOpenAIClient)
 	mockCache := new(MockCache)
 
-	categorizer := NewCategorizer(mockClient, mockCache)
+	categorizer := NewCategorizer(mockClient, mockCache, "")
 
 	// Test with empty items
 	result, err := categorizer.CategorizeItems(ctx, []Item{}, []Category{{ID: "cat_1", Name: "Groceries"}})
@@ -249,7 +255,7 @@ func TestCategorizer_CategorizeItems_OpenAIError(t *testing.T) {
 	mockClient := new(MockOpenAIClient)
 	mockCache := new(MockCache)
 
-	categorizer := NewCategorizer(mockClient, mockCache)
+	categorizer := NewCategorizer(mockClient, mockCache, "")
 
 	items := []Item{
 		{Name: "Test Item", Price: 10.00},
@@ -329,7 +335,7 @@ func TestCategorizer_CategorizeItems_RetriesOnTransientError(t *testing.T) {
 	mockClient := new(MockOpenAIClient)
 	mockCache := new(MockCache)
 
-	categorizer := NewCategorizer(mockClient, mockCache)
+	categorizer := NewCategorizer(mockClient, mockCache, "")
 
 	items := []Item{
 		{Name: "Test Item", Price: 10.00},
@@ -385,7 +391,7 @@ func TestCategorizer_CategorizeItems_ExhaustsRetries(t *testing.T) {
 	mockClient := new(MockOpenAIClient)
 	mockCache := new(MockCache)
 
-	categorizer := NewCategorizer(mockClient, mockCache)
+	categorizer := NewCategorizer(mockClient, mockCache, "")
 
 	items := []Item{
 		{Name: "Test Item", Price: 10.00},
@@ -412,4 +418,10 @@ func TestCategorizer_CategorizeItems_ExhaustsRetries(t *testing.T) {
 	// Verify OpenAI was called 3 times (all retries exhausted)
 	mockClient.AssertNumberOfCalls(t, "CreateChatCompletion", 3)
 	mockCache.AssertExpectations(t)
+}
+
+func TestNewCategorizer_DefaultsModelWhenEmpty(t *testing.T) {
+	categorizer := NewCategorizer(new(MockOpenAIClient), new(MockCache), "")
+
+	assert.Equal(t, "gpt-5.4-nano", categorizer.Model)
 }

--- a/internal/infrastructure/config/config.go
+++ b/internal/infrastructure/config/config.go
@@ -122,7 +122,7 @@ func LoadFromEnv() *Config {
 		},
 		OpenAI: OpenAIConfig{
 			APIKey: os.Getenv("OPENAI_API_KEY"),
-			Model:  getEnv("OPENAI_MODEL", "gpt-4o"),
+			Model:  getEnv("OPENAI_MODEL", "gpt-5.4-nano"),
 		},
 		Providers: ProvidersConfig{
 			Walmart: WalmartConfig{

--- a/internal/infrastructure/config/config_test.go
+++ b/internal/infrastructure/config/config_test.go
@@ -37,7 +37,7 @@ func TestLoadFromYAML(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, cfg)
 	assert.Equal(t, "monarch_sync.db", cfg.Storage.DatabasePath)
-	assert.Equal(t, "gpt-4o", cfg.OpenAI.Model)
+	assert.Equal(t, "gpt-5.4-nano", cfg.OpenAI.Model)
 }
 
 func TestLoadFromEnv(t *testing.T) {
@@ -66,7 +66,7 @@ func TestLoadFromEnv_Defaults(t *testing.T) {
 	cfg := LoadFromEnv()
 	assert.NotNil(t, cfg)
 	assert.Equal(t, "monarch_sync.db", cfg.Storage.DatabasePath)
-	assert.Equal(t, "gpt-4o", cfg.OpenAI.Model)
+	assert.Equal(t, "gpt-5.4-nano", cfg.OpenAI.Model)
 }
 
 func TestLoadOrEnv(t *testing.T) {


### PR DESCRIPTION
## Summary
- Wire configured OpenAI model into the categorizer instead of hardcoding gpt-4o
- Default OPENAI_MODEL/config samples to gpt-5.4-nano
- Omit temperature for gpt-5-family models and send low reasoning_effort; keep temperature 0.1 for non-gpt-5 models

## Verification
- go test ./... -race
- go build -o itemize ./cmd/itemize/

No Monarch writes in tests.