### PR TITLE
Persist Amazon scraper browser profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,14 @@ Uses credentials saved by [costco-go](https://github.com/eshaffer321/costco-go).
 Requires [amazon-order-scraper](https://www.npmjs.com/package/amazon-order-scraper) CLI:
 ```bash
 npm install -g amazon-order-scraper
-amazon-scraper --login  # authenticate once
+BROWSER_DATA_DIR="$HOME/.itemize/amazon" amazon-scraper --login  # authenticate once
+```
+
+`itemize` uses the same persistent browser profile base by default. If you set
+`AMAZON_ACCOUNT_NAME`, pass the matching scraper profile during login:
+
+```bash
+BROWSER_DATA_DIR="$HOME/.itemize/amazon" amazon-scraper --login --profile "$AMAZON_ACCOUNT_NAME"
 ```
 
 ## Troubleshooting

--- a/config.yaml
+++ b/config.yaml
@@ -27,6 +27,7 @@ providers:
     max_orders: 0
     debug: false
     account_name: "${AMAZON_ACCOUNT_NAME}"
+    browser_data_dir: "${AMAZON_BROWSER_DATA_DIR}"
 
 # Monarch Money API configuration
 monarch:

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-replace github.com/eshaffer321/costco-go => /Users/erickshaffer/code/costco-go
-
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/getsentry/sentry-go v0.36.0 // indirect

--- a/internal/adapters/providers/amazon/provider.go
+++ b/internal/adapters/providers/amazon/provider.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -35,16 +36,18 @@ func isValidProfile(profile string) bool {
 // Provider implements the OrderProvider interface for Amazon
 // It shells out to the amazon-order-scraper CLI (npm package)
 type Provider struct {
-	logger    *slog.Logger
-	rateLimit time.Duration
-	profile   string // Optional profile name for multi-account support
-	headless  bool   // Run browser in headless mode
+	logger         *slog.Logger
+	rateLimit      time.Duration
+	profile        string // Optional profile name for multi-account support
+	headless       bool   // Run browser in headless mode
+	browserDataDir string // Base directory for persistent Amazon browser profiles
 }
 
 // ProviderConfig holds configuration for the Amazon provider
 type ProviderConfig struct {
-	Profile  string // Profile name for multi-account support
-	Headless bool   // Run in headless mode (for automated/cron runs)
+	Profile        string // Profile name for multi-account support
+	Headless       bool   // Run in headless mode (for automated/cron runs)
+	BrowserDataDir string // Base directory for persistent browser profiles
 }
 
 // NewProvider creates a new Amazon provider
@@ -55,6 +58,7 @@ func NewProvider(logger *slog.Logger, cfg *ProviderConfig) *Provider {
 
 	profile := ""
 	headless := false
+	browserDataDir := ""
 	if cfg != nil {
 		// Validate profile name to prevent command injection
 		if cfg.Profile != "" {
@@ -66,13 +70,15 @@ func NewProvider(logger *slog.Logger, cfg *ProviderConfig) *Provider {
 			}
 		}
 		headless = cfg.Headless
+		browserDataDir = cfg.BrowserDataDir
 	}
 
 	return &Provider{
-		logger:    logger.With(slog.String("provider", "amazon")),
-		rateLimit: 1 * time.Second,
-		profile:   profile,
-		headless:  headless,
+		logger:         logger.With(slog.String("provider", "amazon")),
+		rateLimit:      1 * time.Second,
+		profile:        profile,
+		headless:       headless,
+		browserDataDir: browserDataDir,
 	}
 }
 
@@ -199,6 +205,9 @@ func (p *Provider) executeCLI(ctx context.Context, args []string) ([]byte, error
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
+	if p.browserDataDir != "" {
+		cmd.Env = append(os.Environ(), "BROWSER_DATA_DIR="+p.browserDataDir)
+	}
 
 	err := cmd.Run()
 	if err != nil {
@@ -207,7 +216,7 @@ func (p *Provider) executeCLI(ctx context.Context, args []string) ([]byte, error
 			exitCode := exitErr.ExitCode()
 			switch exitCode {
 			case 2:
-				return nil, fmt.Errorf("amazon login required: run 'amazon-scraper --login' to authenticate")
+				return nil, fmt.Errorf("amazon login required: %s", p.loginCommand())
 			default:
 				return nil, fmt.Errorf("CLI failed (exit %d): %s", exitCode, stderr.String())
 			}
@@ -216,6 +225,17 @@ func (p *Provider) executeCLI(ctx context.Context, args []string) ([]byte, error
 	}
 
 	return stdout.Bytes(), nil
+}
+
+func (p *Provider) loginCommand() string {
+	profileArg := ""
+	if p.profile != "" {
+		profileArg = " --profile " + p.profile
+	}
+	if p.browserDataDir != "" {
+		return fmt.Sprintf("run 'BROWSER_DATA_DIR=%q npx -y amazon-order-scraper --login%s' to authenticate", p.browserDataDir, profileArg)
+	}
+	return fmt.Sprintf("run 'amazon-scraper --login%s' to authenticate", profileArg)
 }
 
 // findCLI locates the amazon-order-scraper CLI

--- a/internal/adapters/providers/amazon/provider_test.go
+++ b/internal/adapters/providers/amazon/provider_test.go
@@ -48,13 +48,15 @@ func TestProvider_MerchantSearchTerms(t *testing.T) {
 // TestProvider_WithConfig tests provider creation with config
 func TestProvider_WithConfig(t *testing.T) {
 	cfg := &ProviderConfig{
-		Profile:  "wife",
-		Headless: true,
+		Profile:        "wife",
+		Headless:       true,
+		BrowserDataDir: "/tmp/itemize-amazon",
 	}
 
 	provider := NewProvider(nil, cfg)
 	assert.Equal(t, "wife", provider.profile)
 	assert.True(t, provider.headless)
+	assert.Equal(t, "/tmp/itemize-amazon", provider.browserDataDir)
 }
 
 // TestProvider_BuildCLIArgs tests CLI argument building

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -83,11 +83,35 @@ func NewAmazonProvider(cfg *config.Config, verbose bool) (providers.OrderProvide
 	}
 	amazonLogger := logging.NewLoggerWithSystem(loggingCfg, "amazon")
 
+	browserDataDir, err := resolveAmazonBrowserDataDir(cfg.Providers.Amazon.BrowserDataDir)
+	if err != nil {
+		return nil, err
+	}
+
 	// Build provider config
 	providerCfg := &amazonprovider.ProviderConfig{
-		Profile:  cfg.Providers.Amazon.AccountName,
-		Headless: false, // Default to non-headless for interactive use
+		Profile:        cfg.Providers.Amazon.AccountName,
+		Headless:       false, // Default to non-headless for interactive use
+		BrowserDataDir: browserDataDir,
 	}
 
 	return amazonprovider.NewProvider(amazonLogger, providerCfg), nil
+}
+
+func resolveAmazonBrowserDataDir(configured string) (string, error) {
+	if configured != "" {
+		return configured, nil
+	}
+	if envDir := os.Getenv("AMAZON_BROWSER_DATA_DIR"); envDir != "" {
+		return envDir, nil
+	}
+	if envDir := os.Getenv("BROWSER_DATA_DIR"); envDir != "" {
+		return envDir, nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	return filepath.Join(homeDir, ".itemize", "amazon"), nil
 }

--- a/internal/infrastructure/config/config.go
+++ b/internal/infrastructure/config/config.go
@@ -73,12 +73,13 @@ type CostcoConfig struct {
 
 // AmazonConfig holds Amazon-specific settings
 type AmazonConfig struct {
-	Enabled      bool   `yaml:"enabled"`
-	RateLimit    string `yaml:"rate_limit"`
-	LookbackDays int    `yaml:"lookback_days"`
-	MaxOrders    int    `yaml:"max_orders"`
-	Debug        bool   `yaml:"debug"`
-	AccountName  string `yaml:"account_name"` // For multi-account support (optional)
+	Enabled        bool   `yaml:"enabled"`
+	RateLimit      string `yaml:"rate_limit"`
+	LookbackDays   int    `yaml:"lookback_days"`
+	MaxOrders      int    `yaml:"max_orders"`
+	Debug          bool   `yaml:"debug"`
+	AccountName    string `yaml:"account_name"`     // For multi-account support (optional)
+	BrowserDataDir string `yaml:"browser_data_dir"` // Base directory for Amazon scraper browser profiles
 }
 
 // ObservabilityConfig holds observability settings
@@ -136,10 +137,11 @@ func LoadFromEnv() *Config {
 				MaxOrders:    getEnvInt("COSTCO_MAX_ORDERS", 0),
 			},
 			Amazon: AmazonConfig{
-				Enabled:      true,
-				LookbackDays: getEnvInt("AMAZON_LOOKBACK_DAYS", 14),
-				MaxOrders:    getEnvInt("AMAZON_MAX_ORDERS", 0),
-				AccountName:  getEnv("AMAZON_ACCOUNT_NAME", ""),
+				Enabled:        true,
+				LookbackDays:   getEnvInt("AMAZON_LOOKBACK_DAYS", 14),
+				MaxOrders:      getEnvInt("AMAZON_MAX_ORDERS", 0),
+				AccountName:    getEnv("AMAZON_ACCOUNT_NAME", ""),
+				BrowserDataDir: getEnv("AMAZON_BROWSER_DATA_DIR", getEnv("BROWSER_DATA_DIR", "")),
 			},
 		},
 		Observability: ObservabilityConfig{


### PR DESCRIPTION
## Summary
- default Amazon scraper browser profiles to a stable ~/.itemize/amazon base directory
- pass BROWSER_DATA_DIR through to amazon-order-scraper and improve login-required guidance
- document profile-specific Amazon login setup

## Tests
- go test ./...