### PR TITLE
refactor: rename module to itemize

### DIFF
--- a/cmd/itemize/main.go
+++ b/cmd/itemize/main.go
@@ -6,13 +6,13 @@ import (
 	"log"
 	"os"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/clients"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/application/sync"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/cli"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/config"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/logging"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/storage"
+	"github.com/eshaffer321/itemize/internal/adapters/clients"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/application/sync"
+	"github.com/eshaffer321/itemize/internal/cli"
+	"github.com/eshaffer321/itemize/internal/infrastructure/config"
+	"github.com/eshaffer321/itemize/internal/infrastructure/logging"
+	"github.com/eshaffer321/itemize/internal/infrastructure/storage"
 )
 
 func main() {

--- a/examples/logging_demo.go
+++ b/examples/logging_demo.go
@@ -7,8 +7,8 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/config"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/logging"
+	"github.com/eshaffer321/itemize/internal/infrastructure/config"
+	"github.com/eshaffer321/itemize/internal/infrastructure/logging"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-replace github.com/eshaffer321/costco-go => /Users/erickshaffer/code/costco-go
-
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/getsentry/sentry-go v0.36.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/eshaffer321/monarchmoney-sync-backend
+module github.com/eshaffer321/itemize
 
 go 1.25.11
 

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/eshaffer321/costco-go v0.3.11 h1:vOEXcSj/vGlwE/4AbXK3uUdXG7XYg1qfUPViujJRS7Q=
-github.com/eshaffer321/costco-go v0.3.11/go.mod h1:ANJTHfRSPyot9cWKNlfs5qDKRKkA4tYORrorvWx/vbM=
 github.com/eshaffer321/monarchmoney-go v1.0.5 h1:V3iP0bvB1q3+m9Gkl6KBCFL44sNsiHDbTxSOU9fHZco=
 github.com/eshaffer321/monarchmoney-go v1.0.5/go.mod h1:ZKPCYT7NcsKGI+YpJ2EqPtfE3dKfuPbiTUrj6J84ot4=
 github.com/eshaffer321/walmart-client-go/v2 v2.0.1 h1:R8NFqKqfdri02Jhmr6jOMpCLAzjdiRbStLtjGKo6WaA=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/eshaffer321/costco-go v0.3.11 h1:vOEXcSj/vGlwE/4AbXK3uUdXG7XYg1qfUPViujJRS7Q=
+github.com/eshaffer321/costco-go v0.3.11/go.mod h1:ANJTHfRSPyot9cWKNlfs5qDKRKkA4tYORrorvWx/vbM=
 github.com/eshaffer321/monarchmoney-go v1.0.5 h1:V3iP0bvB1q3+m9Gkl6KBCFL44sNsiHDbTxSOU9fHZco=
 github.com/eshaffer321/monarchmoney-go v1.0.5/go.mod h1:ZKPCYT7NcsKGI+YpJ2EqPtfE3dKfuPbiTUrj6J84ot4=
 github.com/eshaffer321/walmart-client-go/v2 v2.0.1 h1:R8NFqKqfdri02Jhmr6jOMpCLAzjdiRbStLtjGKo6WaA=

--- a/internal/adapters/clients/anthropic/client.go
+++ b/internal/adapters/clients/anthropic/client.go
@@ -17,7 +17,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/categorizer"
+	"github.com/eshaffer321/itemize/internal/domain/categorizer"
 )
 
 const (

--- a/internal/adapters/clients/anthropic/client_test.go
+++ b/internal/adapters/clients/anthropic/client_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/categorizer"
+	"github.com/eshaffer321/itemize/internal/domain/categorizer"
 )
 
 func float64Ptr(v float64) *float64 { return &v }

--- a/internal/adapters/clients/clients.go
+++ b/internal/adapters/clients/clients.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 
 	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
-	anthropicclient "github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/clients/anthropic"
-	openaiclient "github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/clients/openai"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/categorizer"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/config"
+	anthropicclient "github.com/eshaffer321/itemize/internal/adapters/clients/anthropic"
+	openaiclient "github.com/eshaffer321/itemize/internal/adapters/clients/openai"
+	"github.com/eshaffer321/itemize/internal/domain/categorizer"
+	"github.com/eshaffer321/itemize/internal/infrastructure/config"
 )
 
 const (

--- a/internal/adapters/clients/clients_test.go
+++ b/internal/adapters/clients/clients_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	anthropicclient "github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/clients/anthropic"
-	openaiclient "github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/clients/openai"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/config"
+	anthropicclient "github.com/eshaffer321/itemize/internal/adapters/clients/anthropic"
+	openaiclient "github.com/eshaffer321/itemize/internal/adapters/clients/openai"
+	"github.com/eshaffer321/itemize/internal/infrastructure/config"
 )
 
 func discardLogger() *slog.Logger {

--- a/internal/adapters/clients/openai/client.go
+++ b/internal/adapters/clients/openai/client.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/categorizer"
+	"github.com/eshaffer321/itemize/internal/domain/categorizer"
 )
 
 // Client is the HTTP-backed OpenAI implementation of categorizer.ChatClient.

--- a/internal/adapters/clients/openai/client_test.go
+++ b/internal/adapters/clients/openai/client_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/categorizer"
+	"github.com/eshaffer321/itemize/internal/domain/categorizer"
 )
 
 // newTestClient returns a Client pointed at the given test server.

--- a/internal/adapters/providers/amazon/order.go
+++ b/internal/adapters/providers/amazon/order.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
 )
 
 // ErrPaymentPending indicates an order has no bank charges yet because it hasn't shipped

--- a/internal/adapters/providers/amazon/provider.go
+++ b/internal/adapters/providers/amazon/provider.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
 )
 
 // validProfilePattern matches alphanumeric, dash, and underscore characters only

--- a/internal/adapters/providers/amazon/provider_test.go
+++ b/internal/adapters/providers/amazon/provider_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/adapters/providers/costco/provider.go
+++ b/internal/adapters/providers/costco/provider.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	costcogo "github.com/eshaffer321/costco-go/pkg/costco"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
 )
 
 // Provider implements the OrderProvider interface for Costco

--- a/internal/adapters/providers/costco/provider_test.go
+++ b/internal/adapters/providers/costco/provider_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	costcogo "github.com/eshaffer321/costco-go/pkg/costco"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/adapters/providers/walmart/order.go
+++ b/internal/adapters/providers/walmart/order.go
@@ -6,7 +6,7 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	walmartclient "github.com/eshaffer321/walmart-client-go/v2"
 )
 

--- a/internal/adapters/providers/walmart/order_test.go
+++ b/internal/adapters/providers/walmart/order_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	walmartclient "github.com/eshaffer321/walmart-client-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/internal/adapters/providers/walmart/provider.go
+++ b/internal/adapters/providers/walmart/provider.go
@@ -6,7 +6,7 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	walmartclient "github.com/eshaffer321/walmart-client-go/v2"
 )
 

--- a/internal/adapters/providers/walmart/provider_test.go
+++ b/internal/adapters/providers/walmart/provider_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/api/handlers/base.go
+++ b/internal/api/handlers/base.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/api/dto"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/storage"
+	"github.com/eshaffer321/itemize/internal/api/dto"
+	"github.com/eshaffer321/itemize/internal/infrastructure/storage"
 )
 
 // Base provides shared functionality for all handlers.

--- a/internal/api/handlers/health.go
+++ b/internal/api/handlers/health.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/api/dto"
+	"github.com/eshaffer321/itemize/internal/api/dto"
 )
 
 // HealthHandler handles health check requests.

--- a/internal/api/handlers/health_test.go
+++ b/internal/api/handlers/health_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/api/dto"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/api/handlers"
+	"github.com/eshaffer321/itemize/internal/api/dto"
+	"github.com/eshaffer321/itemize/internal/api/handlers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/api/handlers/items.go
+++ b/internal/api/handlers/items.go
@@ -3,8 +3,8 @@ package handlers
 import (
 	"net/http"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/api/dto"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/storage"
+	"github.com/eshaffer321/itemize/internal/api/dto"
+	"github.com/eshaffer321/itemize/internal/infrastructure/storage"
 )
 
 // ItemsHandler handles item-related HTTP requests.

--- a/internal/api/handlers/items_test.go
+++ b/internal/api/handlers/items_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/api/dto"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/api/handlers"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/storage"
+	"github.com/eshaffer321/itemize/internal/api/dto"
+	"github.com/eshaffer321/itemize/internal/api/handlers"
+	"github.com/eshaffer321/itemize/internal/infrastructure/storage"
 )
 
 func TestItemsHandler_Search(t *testing.T) {

--- a/internal/api/handlers/ledgers.go
+++ b/internal/api/handlers/ledgers.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/api/dto"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/storage"
+	"github.com/eshaffer321/itemize/internal/api/dto"
+	"github.com/eshaffer321/itemize/internal/infrastructure/storage"
 )
 
 // LedgersHandler handles ledger-related HTTP requests.

--- a/internal/api/handlers/orders.go
+++ b/internal/api/handlers/orders.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/api/dto"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/storage"
+	"github.com/eshaffer321/itemize/internal/api/dto"
+	"github.com/eshaffer321/itemize/internal/infrastructure/storage"
 )
 
 // OrdersHandler handles order-related HTTP requests.

--- a/internal/api/handlers/orders_test.go
+++ b/internal/api/handlers/orders_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/api/dto"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/api/handlers"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/storage"
+	"github.com/eshaffer321/itemize/internal/api/dto"
+	"github.com/eshaffer321/itemize/internal/api/handlers"
+	"github.com/eshaffer321/itemize/internal/infrastructure/storage"
 )
 
 func TestOrdersHandler_List(t *testing.T) {

--- a/internal/api/handlers/runs.go
+++ b/internal/api/handlers/runs.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/api/dto"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/storage"
+	"github.com/eshaffer321/itemize/internal/api/dto"
+	"github.com/eshaffer321/itemize/internal/infrastructure/storage"
 )
 
 // RunsHandler handles sync run-related HTTP requests.

--- a/internal/api/handlers/runs_test.go
+++ b/internal/api/handlers/runs_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/api/dto"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/api/handlers"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/storage"
+	"github.com/eshaffer321/itemize/internal/api/dto"
+	"github.com/eshaffer321/itemize/internal/api/handlers"
+	"github.com/eshaffer321/itemize/internal/infrastructure/storage"
 )
 
 func TestRunsHandler_List(t *testing.T) {

--- a/internal/api/handlers/stats.go
+++ b/internal/api/handlers/stats.go
@@ -3,8 +3,8 @@ package handlers
 import (
 	"net/http"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/api/dto"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/storage"
+	"github.com/eshaffer321/itemize/internal/api/dto"
+	"github.com/eshaffer321/itemize/internal/infrastructure/storage"
 )
 
 // StatsHandler handles stats-related HTTP requests.

--- a/internal/api/handlers/sync.go
+++ b/internal/api/handlers/sync.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/api/dto"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/application/service"
+	"github.com/eshaffer321/itemize/internal/api/dto"
+	"github.com/eshaffer321/itemize/internal/application/service"
 )
 
 // SyncHandler handles sync-related HTTP requests.

--- a/internal/api/handlers/transactions.go
+++ b/internal/api/handlers/transactions.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/api/dto"
+	"github.com/eshaffer321/itemize/internal/api/dto"
 )
 
 // TransactionsHandler handles transaction-related HTTP requests.

--- a/internal/api/integration_test.go
+++ b/internal/api/integration_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/api"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/api/dto"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/storage"
+	"github.com/eshaffer321/itemize/internal/api"
+	"github.com/eshaffer321/itemize/internal/api/dto"
+	"github.com/eshaffer321/itemize/internal/infrastructure/storage"
 )
 
 // =============================================================================

--- a/internal/api/middleware/middleware_test.go
+++ b/internal/api/middleware/middleware_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/api/middleware"
+	"github.com/eshaffer321/itemize/internal/api/middleware"
 )
 
 func TestLogging(t *testing.T) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -10,10 +10,10 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/api/handlers"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/api/middleware"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/application/service"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/storage"
+	"github.com/eshaffer321/itemize/internal/api/handlers"
+	"github.com/eshaffer321/itemize/internal/api/middleware"
+	"github.com/eshaffer321/itemize/internal/application/service"
+	"github.com/eshaffer321/itemize/internal/infrastructure/storage"
 )
 
 // Config holds API server configuration.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/api"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/api/dto"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/storage"
+	"github.com/eshaffer321/itemize/internal/api"
+	"github.com/eshaffer321/itemize/internal/api/dto"
+	"github.com/eshaffer321/itemize/internal/infrastructure/storage"
 )
 
 func newTestServer(t *testing.T) (*api.Server, *storage.MockRepository) {

--- a/internal/application/service/sync_service.go
+++ b/internal/application/service/sync_service.go
@@ -7,12 +7,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/clients"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
-	appsync "github.com/eshaffer321/monarchmoney-sync-backend/internal/application/sync"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/config"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/logging"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/storage"
+	"github.com/eshaffer321/itemize/internal/adapters/clients"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
+	appsync "github.com/eshaffer321/itemize/internal/application/sync"
+	"github.com/eshaffer321/itemize/internal/infrastructure/config"
+	"github.com/eshaffer321/itemize/internal/infrastructure/logging"
+	"github.com/eshaffer321/itemize/internal/infrastructure/storage"
 )
 
 // SyncStatus represents the current state of a sync job.

--- a/internal/application/sync/consolidator.go
+++ b/internal/application/sync/consolidator.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/storage"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/infrastructure/storage"
 )
 
 // Consolidator handles transaction consolidation for multi-delivery orders

--- a/internal/application/sync/consolidator_test.go
+++ b/internal/application/sync/consolidator_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/application/sync/fetch.go
+++ b/internal/application/sync/fetch.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/categorizer"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/domain/categorizer"
 )
 
 // Data fetching functions for the sync orchestrator.

--- a/internal/application/sync/handlers/amazon.go
+++ b/internal/application/sync/handlers/amazon.go
@@ -11,12 +11,12 @@ import (
 	"time"
 
 	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
-	amazonprovider "github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers/amazon"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/allocator"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/categorizer"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/matcher"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/validator"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
+	amazonprovider "github.com/eshaffer321/itemize/internal/adapters/providers/amazon"
+	"github.com/eshaffer321/itemize/internal/domain/allocator"
+	"github.com/eshaffer321/itemize/internal/domain/categorizer"
+	"github.com/eshaffer321/itemize/internal/domain/matcher"
+	"github.com/eshaffer321/itemize/internal/domain/validator"
 )
 
 // AmazonOrder extends providers.Order with Amazon-specific methods

--- a/internal/application/sync/handlers/amazon_test.go
+++ b/internal/application/sync/handlers/amazon_test.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
-	amazonprovider "github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers/amazon"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/categorizer"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/matcher"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
+	amazonprovider "github.com/eshaffer321/itemize/internal/adapters/providers/amazon"
+	"github.com/eshaffer321/itemize/internal/domain/categorizer"
+	"github.com/eshaffer321/itemize/internal/domain/matcher"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/application/sync/handlers/simple.go
+++ b/internal/application/sync/handlers/simple.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 
 	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/categorizer"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/matcher"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/domain/categorizer"
+	"github.com/eshaffer321/itemize/internal/domain/matcher"
 )
 
 // SimpleHandler processes orders for simple providers like Costco

--- a/internal/application/sync/handlers/simple_test.go
+++ b/internal/application/sync/handlers/simple_test.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/categorizer"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/matcher"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/domain/categorizer"
+	"github.com/eshaffer321/itemize/internal/domain/matcher"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/application/sync/handlers/walmart.go
+++ b/internal/application/sync/handlers/walmart.go
@@ -11,10 +11,10 @@ import (
 	"time"
 
 	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
-	walmartprovider "github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers/walmart"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/categorizer"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/matcher"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
+	walmartprovider "github.com/eshaffer321/itemize/internal/adapters/providers/walmart"
+	"github.com/eshaffer321/itemize/internal/domain/categorizer"
+	"github.com/eshaffer321/itemize/internal/domain/matcher"
 )
 
 // WalmartOrder extends providers.Order with Walmart-specific methods

--- a/internal/application/sync/handlers/walmart_test.go
+++ b/internal/application/sync/handlers/walmart_test.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/categorizer"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/matcher"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/domain/categorizer"
+	"github.com/eshaffer321/itemize/internal/domain/matcher"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/application/sync/orchestrator.go
+++ b/internal/application/sync/orchestrator.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 
 	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/application/sync/handlers"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/categorizer"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/application/sync/handlers"
+	"github.com/eshaffer321/itemize/internal/domain/categorizer"
 )
 
 // handleResult processes the result from a provider handler and records success/error

--- a/internal/application/sync/orchestrator_process_test.go
+++ b/internal/application/sync/orchestrator_process_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/application/sync/orchestrator_test.go
+++ b/internal/application/sync/orchestrator_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/internal/application/sync/process_order_test.go
+++ b/internal/application/sync/process_order_test.go
@@ -8,11 +8,11 @@ import (
 	"time"
 
 	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/application/sync/handlers"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/categorizer"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/matcher"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/splitter"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/application/sync/handlers"
+	"github.com/eshaffer321/itemize/internal/domain/categorizer"
+	"github.com/eshaffer321/itemize/internal/domain/matcher"
+	"github.com/eshaffer321/itemize/internal/domain/splitter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/application/sync/recording.go
+++ b/internal/application/sync/recording.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/application/sync/handlers"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/storage"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/application/sync/handlers"
+	"github.com/eshaffer321/itemize/internal/infrastructure/storage"
 )
 
 // convertOrderItems converts provider order items to storage order items

--- a/internal/application/sync/types.go
+++ b/internal/application/sync/types.go
@@ -5,13 +5,13 @@ import (
 	"log/slog"
 
 	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/clients"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/application/sync/handlers"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/categorizer"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/matcher"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/splitter"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/storage"
+	"github.com/eshaffer321/itemize/internal/adapters/clients"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/application/sync/handlers"
+	"github.com/eshaffer321/itemize/internal/domain/categorizer"
+	"github.com/eshaffer321/itemize/internal/domain/matcher"
+	"github.com/eshaffer321/itemize/internal/domain/splitter"
+	"github.com/eshaffer321/itemize/internal/infrastructure/storage"
 )
 
 // ProgressUpdate represents a progress update during sync

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/application/sync"
+	"github.com/eshaffer321/itemize/internal/application/sync"
 )
 
 // SyncFlags are common flags for all sync commands

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/application/sync"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/storage"
+	"github.com/eshaffer321/itemize/internal/application/sync"
+	"github.com/eshaffer321/itemize/internal/infrastructure/storage"
 )
 
 // PrintHeader prints the application header

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -7,12 +7,12 @@ import (
 	"time"
 
 	costcogo "github.com/eshaffer321/costco-go/pkg/costco"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
-	amazonprovider "github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers/amazon"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers/costco"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers/walmart"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/config"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/logging"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
+	amazonprovider "github.com/eshaffer321/itemize/internal/adapters/providers/amazon"
+	"github.com/eshaffer321/itemize/internal/adapters/providers/costco"
+	"github.com/eshaffer321/itemize/internal/adapters/providers/walmart"
+	"github.com/eshaffer321/itemize/internal/infrastructure/config"
+	"github.com/eshaffer321/itemize/internal/infrastructure/logging"
 	walmartclient "github.com/eshaffer321/walmart-client-go/v2"
 )
 

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -11,13 +11,13 @@ import (
 	"time"
 
 	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/clients"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/api"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/application/service"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/config"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/logging"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/storage"
+	"github.com/eshaffer321/itemize/internal/adapters/clients"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/api"
+	"github.com/eshaffer321/itemize/internal/application/service"
+	"github.com/eshaffer321/itemize/internal/infrastructure/config"
+	"github.com/eshaffer321/itemize/internal/infrastructure/logging"
+	"github.com/eshaffer321/itemize/internal/infrastructure/storage"
 )
 
 // ServeFlags holds the CLI flags for the serve command.

--- a/internal/domain/matcher/matcher.go
+++ b/internal/domain/matcher/matcher.go
@@ -21,7 +21,7 @@ import (
 	"math"
 
 	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
 )
 
 // Matcher matches orders with Monarch transactions

--- a/internal/domain/matcher/matcher_test.go
+++ b/internal/domain/matcher/matcher_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/domain/matcher/multi.go
+++ b/internal/domain/matcher/multi.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
 )
 
 // MultiMatchResult contains results from multi-transaction matching

--- a/internal/domain/splitter/splitter.go
+++ b/internal/domain/splitter/splitter.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/categorizer"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/domain/categorizer"
 )
 
 // Categorizer interface for dependency injection

--- a/internal/domain/splitter/splitter_test.go
+++ b/internal/domain/splitter/splitter_test.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/adapters/providers"
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/domain/categorizer"
+	"github.com/eshaffer321/itemize/internal/adapters/providers"
+	"github.com/eshaffer321/itemize/internal/domain/categorizer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/infrastructure/logging/logger.go
+++ b/internal/infrastructure/logging/logger.go
@@ -9,7 +9,7 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/config"
+	"github.com/eshaffer321/itemize/internal/infrastructure/config"
 )
 
 // logFile holds the open log file handle for cleanup

--- a/internal/infrastructure/logging/logger_test.go
+++ b/internal/infrastructure/logging/logger_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/config"
+	"github.com/eshaffer321/itemize/internal/infrastructure/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/infrastructure/storage/sqlite.go
+++ b/internal/infrastructure/storage/sqlite.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pressly/goose/v3"
 
 	// Import migrations package to register Go migrations
-	_ "github.com/eshaffer321/monarchmoney-sync-backend/internal/infrastructure/storage/migrations"
+	_ "github.com/eshaffer321/itemize/internal/infrastructure/storage/migrations"
 )
 
 //go:embed migrations/*.sql


### PR DESCRIPTION
## Summary
Rename the Go module from `github.com/eshaffer321/monarchmoney-sync-backend` to `github.com/eshaffer321/itemize` to align the codebase with the project's actual name.

- Updated `go.mod` module declaration
- Updated all 155 import statements across the codebase
- Ran `go mod tidy` to sync dependencies
- All tests pass with race detector

## Test plan
- [x] Build succeeds (`make build`)
- [x] All tests pass (`go test ./... -race`)
- [x] No remaining references to old module name