### PR TITLE
chore: update branding from Monarch Money to Monarch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 **Last Updated:** June 2026
 
-CLI + API server that syncs Walmart, Costco, and Amazon purchases into Monarch Money:
+CLI + API server that syncs Walmart, Costco, and Amazon purchases into Monarch:
 matches each order to its Monarch transaction, categorizes items with OpenAI, and splits
 the transaction by category. Local single-user tool — not a SaaS, extension, or real-time service.
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Itemize
 
-CLI tool that syncs purchases from Walmart, Costco, and Amazon with Monarch Money. Automatically splits transactions by category using AI.
+CLI tool that syncs purchases from Walmart, Costco, and Amazon with Monarch. Automatically splits transactions by category using AI.
 
 ## What it does
 
 1. Fetches orders from retailers with item details
-2. Matches them to transactions in Monarch Money
+2. Matches them to transactions in Monarch
 3. Categorizes items using an LLM (OpenAI or Anthropic Claude)
 4. Splits the transaction by category with proportional tax
 
@@ -19,7 +19,7 @@ CLI tool that syncs purchases from Walmart, Costco, and Amazon with Monarch Mone
 ### Prerequisites
 
 - Go 1.24+
-- Monarch Money account
+- Monarch account
 - An LLM API key — OpenAI or Anthropic (Claude)
 - Retailer account(s)
 
@@ -124,7 +124,7 @@ BROWSER_DATA_DIR="$HOME/.itemize/amazon" amazon-scraper --login --profile "$AMAZ
 ## Troubleshooting
 
 **"No matching transaction found"**
-- Transaction hasn't posted to Monarch yet (wait 1-3 days)
+- Transaction hasn't posted to Monarch yet (wait 1–3 days)
 - Amount differs by more than $0.01
 - Date differs by more than 5 days
 

--- a/cmd/itemize/main.go
+++ b/cmd/itemize/main.go
@@ -127,7 +127,7 @@ func printUsage() {
 	fmt.Println("  -order-id string Process only this specific order ID (limits blast radius)")
 	fmt.Println()
 	fmt.Println("Environment Variables:")
-	fmt.Println("  MONARCH_TOKEN              Monarch Money API token (required)")
+	fmt.Println("  MONARCH_TOKEN              Monarch API token (required)")
 	fmt.Println("  OPENAI_API_KEY             OpenAI API key")
 	fmt.Println("  ANTHROPIC_API_KEY          Anthropic Claude API key")
 	fmt.Println("  CATEGORIZER_PROVIDER       Force backend: 'openai' or 'anthropic'")

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-# Monarch Money Sync Backend Configuration
+# Monarch Sync Backend Configuration
 
 # Provider configurations
 providers:
@@ -29,7 +29,7 @@ providers:
     account_name: "${AMAZON_ACCOUNT_NAME}"
     browser_data_dir: "${AMAZON_BROWSER_DATA_DIR}"
 
-# Monarch Money API configuration
+# Monarch API configuration
 monarch:
   api_key: "${MONARCH_TOKEN}"
 

--- a/docs/adding-providers.md
+++ b/docs/adding-providers.md
@@ -1,6 +1,6 @@
 # Adding New Providers
 
-This guide explains how to add support for new stores (like Costco, Target, Amazon) to the Monarch Money Sync Backend.
+This guide explains how to add support for new stores (like Costco, Target, Amazon) to the Monarch Sync Backend.
 
 ## Overview
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-The Monarch Money Sync Backend follows a **layered architecture** pattern with clear separation of concerns. This structure emerged from refactoring a flat directory layout that made it difficult to understand where components belonged.
+The Monarch Sync Backend follows a **layered architecture** pattern with clear separation of concerns. This structure emerged from refactoring a flat directory layout that made it difficult to understand where components belonged.
 
 ## Directory Structure
 

--- a/docs/deduplication-safety.md
+++ b/docs/deduplication-safety.md
@@ -1,7 +1,7 @@
 # Deduplication & Database Safety
 
 ## Overview
-This document explains how the sync system prevents duplicate processing and protects your Monarch Money budget from corruption.
+This document explains how the sync system prevents duplicate processing and protects your Monarch budget from corruption.
 
 ## Two-Layer Protection System
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -37,7 +37,7 @@ Each component has a **system prefix** to identify the source:
 - `[sync]` - Orchestrator and application logic
 - `[costco]` - Costco provider and costco-go client
 - `[walmart]` - Walmart provider and walmart-client
-- `[monarch]` - Monarch Money API client
+- `[monarch]` - Monarch API client
 - `[storage]` - Database operations
 - `[categorizer]` - AI categorization logic
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -172,7 +172,7 @@ When fixing a bug:
 ## Next Testing Priorities
 
 1. Add service layer tests
-2. Add Monarch Money SDK integration tests (mocked)
+2. Add Monarch SDK integration tests (mocked)
 3. Add configuration tests
 4. Add main.go integration tests
 5. Add performance benchmarks

--- a/internal/adapters/providers/walmart/order.go
+++ b/internal/adapters/providers/walmart/order.go
@@ -228,7 +228,7 @@ func (o *Order) GetFinalCharges() ([]float64, error) {
 
 	// TODO: Handle refund transactions (negative charges)
 	// Currently we skip negative charges in the ledger, which means refund
-	// transactions in Monarch Money won't be categorized. Future enhancement:
+	// transactions in Monarch won't be categorized. Future enhancement:
 	// 1. Match the refund transaction (positive amount in Monarch)
 	// 2. Determine which item(s) were refunded from the ledger
 	// 3. Categorize the refund with the same category as the refunded item

--- a/internal/api/dto/transactions.go
+++ b/internal/api/dto/transactions.go
@@ -1,6 +1,6 @@
 package dto
 
-// TransactionResponse represents a Monarch Money transaction in API responses.
+// TransactionResponse represents a Monarch transaction in API responses.
 type TransactionResponse struct {
 	ID              string                      `json:"id"`
 	Date            string                      `json:"date"`

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -121,7 +121,7 @@ func (s *Server) setupRoutes() {
 			r.Delete("/sync/{jobId}", syncHandler.CancelSync)
 		}
 
-		// Transactions (Monarch Money)
+		// Transactions (Monarch)
 		if s.monarchClient != nil {
 			transactionsHandler := handlers.NewTransactionsHandler(s.monarchClient)
 			r.Get("/transactions", transactionsHandler.List)

--- a/internal/application/sync/fetch.go
+++ b/internal/application/sync/fetch.go
@@ -39,7 +39,7 @@ func (o *Orchestrator) fetchOrders(ctx context.Context, opts Options) ([]provide
 	return orders, nil
 }
 
-// fetchMonarchTransactions fetches and filters transactions from Monarch Money
+// fetchMonarchTransactions fetches and filters transactions from Monarch
 func (o *Orchestrator) fetchMonarchTransactions(ctx context.Context, opts Options) ([]*monarch.Transaction, error) {
 	o.logger.Debug("Fetching Monarch transactions")
 

--- a/internal/application/sync/handlers/amazon.go
+++ b/internal/application/sync/handlers/amazon.go
@@ -48,7 +48,7 @@ type CategorySplitter interface {
 	GetSingleCategoryInfo(ctx context.Context, order providers.Order, categories []categorizer.Category) (string, string, error)
 }
 
-// MonarchClient provides access to Monarch Money API
+// MonarchClient provides access to Monarch API
 type MonarchClient interface {
 	UpdateTransaction(ctx context.Context, id string, params *monarch.UpdateTransactionParams) error
 	UpdateSplits(ctx context.Context, id string, splits []*monarch.TransactionSplit) error

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -35,7 +35,7 @@ func ParseSyncFlags() SyncFlags {
 		flag.PrintDefaults()
 		fmt.Fprintln(os.Stderr)
 		fmt.Fprintln(os.Stderr, "Environment Variables:")
-		fmt.Fprintln(os.Stderr, "  MONARCH_TOKEN              Monarch Money API token (required)")
+		fmt.Fprintln(os.Stderr, "  MONARCH_TOKEN              Monarch API token (required)")
 		fmt.Fprintln(os.Stderr, "  OPENAI_API_KEY             OpenAI API key")
 		fmt.Fprintln(os.Stderr, "  ANTHROPIC_API_KEY          Anthropic Claude API key")
 		fmt.Fprintln(os.Stderr, "  CATEGORIZER_PROVIDER       Force backend: 'openai' or 'anthropic'")

--- a/internal/domain/categorizer/categorizer.go
+++ b/internal/domain/categorizer/categorizer.go
@@ -16,7 +16,7 @@ type Item struct {
 	Quantity int     `json:"quantity,omitempty"`
 }
 
-// Category represents a Monarch Money category
+// Category represents a Monarch category
 type Category struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`

--- a/internal/domain/matcher/matcher.go
+++ b/internal/domain/matcher/matcher.go
@@ -1,5 +1,5 @@
 // Package matcher provides transaction matching logic for syncing
-// provider orders with Monarch Money transactions.
+// provider orders with Monarch transactions.
 //
 // The matcher uses strict matching criteria:
 //   - Amount must match within 1 cent (configurable)

--- a/internal/infrastructure/config/config.go
+++ b/internal/infrastructure/config/config.go
@@ -36,7 +36,7 @@ type StorageConfig struct {
 	DatabasePath string `yaml:"database_path"`
 }
 
-// MonarchConfig holds Monarch Money API configuration
+// MonarchConfig holds Monarch API configuration
 type MonarchConfig struct {
 	APIKey string `yaml:"api_key"`
 }


### PR DESCRIPTION
## Summary
- Replaces all user-facing and documentation references to "Monarch Money" with "Monarch" to reflect the company's rebrand
- Leaves identifiers untouched (`MONARCH_TOKEN`, `MonarchConfig`, `monarchmoney-go` package name, etc.)

## Files changed
- `config.yaml`, `README.md`, `AGENTS.md` — top-level docs/config
- `cmd/itemize/main.go`, `internal/cli/flags.go` — help text strings
- 8 source files — comments only (no logic changed)
- 5 docs files