### PR TITLE
chore: bump monarch-go to v2.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.11
 
 require (
 	github.com/eshaffer321/costco-go v0.3.11
-	github.com/eshaffer321/monarchmoney-go v1.0.5
+	github.com/eshaffer321/monarch-go/v2 v2.0.0
 	github.com/eshaffer321/walmart-client-go/v2 v2.0.1
 	github.com/getsentry/sentry-go v0.36.0
 	github.com/go-chi/chi/v5 v5.2.5

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/eshaffer321/costco-go v0.3.11 h1:vOEXcSj/vGlwE/4AbXK3uUdXG7XYg1qfUPViujJRS7Q=
 github.com/eshaffer321/costco-go v0.3.11/go.mod h1:ANJTHfRSPyot9cWKNlfs5qDKRKkA4tYORrorvWx/vbM=
-github.com/eshaffer321/monarchmoney-go v1.0.5 h1:V3iP0bvB1q3+m9Gkl6KBCFL44sNsiHDbTxSOU9fHZco=
-github.com/eshaffer321/monarchmoney-go v1.0.5/go.mod h1:ZKPCYT7NcsKGI+YpJ2EqPtfE3dKfuPbiTUrj6J84ot4=
+github.com/eshaffer321/monarch-go/v2 v2.0.0 h1:3reQ15D0K/Btc3mu+sfWdKJnU0hmNb0/ZwsbVUjN4l8=
+github.com/eshaffer321/monarch-go/v2 v2.0.0/go.mod h1:0rdAjSetvYQ8wGkUdg4BsqN8jTMhJ4TbHAr6qhAzSk4=
 github.com/eshaffer321/walmart-client-go/v2 v2.0.1 h1:R8NFqKqfdri02Jhmr6jOMpCLAzjdiRbStLtjGKo6WaA=
 github.com/eshaffer321/walmart-client-go/v2 v2.0.1/go.mod h1:4PVK9TsqFscTZypC67dgCt/vnPxXdtaheJVM7HOnod0=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=

--- a/internal/adapters/clients/clients.go
+++ b/internal/adapters/clients/clients.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	anthropicclient "github.com/eshaffer321/itemize/internal/adapters/clients/anthropic"
 	openaiclient "github.com/eshaffer321/itemize/internal/adapters/clients/openai"
 	"github.com/eshaffer321/itemize/internal/domain/categorizer"

--- a/internal/api/handlers/transactions.go
+++ b/internal/api/handlers/transactions.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/api/dto"
 )
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/api/handlers"
 	"github.com/eshaffer321/itemize/internal/api/middleware"
 	"github.com/eshaffer321/itemize/internal/application/service"

--- a/internal/application/sync/consolidator.go
+++ b/internal/application/sync/consolidator.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/eshaffer321/itemize/internal/infrastructure/storage"
 )

--- a/internal/application/sync/consolidator_test.go
+++ b/internal/application/sync/consolidator_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/internal/application/sync/fetch.go
+++ b/internal/application/sync/fetch.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/eshaffer321/itemize/internal/domain/categorizer"
 )

--- a/internal/application/sync/handlers/amazon.go
+++ b/internal/application/sync/handlers/amazon.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	amazonprovider "github.com/eshaffer321/itemize/internal/adapters/providers/amazon"
 	"github.com/eshaffer321/itemize/internal/domain/allocator"

--- a/internal/application/sync/handlers/amazon_test.go
+++ b/internal/application/sync/handlers/amazon_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	amazonprovider "github.com/eshaffer321/itemize/internal/adapters/providers/amazon"
 	"github.com/eshaffer321/itemize/internal/domain/categorizer"

--- a/internal/application/sync/handlers/simple.go
+++ b/internal/application/sync/handlers/simple.go
@@ -7,7 +7,7 @@ import (
 	"math"
 	"strings"
 
-	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/eshaffer321/itemize/internal/domain/categorizer"
 	"github.com/eshaffer321/itemize/internal/domain/matcher"

--- a/internal/application/sync/handlers/simple_test.go
+++ b/internal/application/sync/handlers/simple_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/eshaffer321/itemize/internal/domain/categorizer"
 	"github.com/eshaffer321/itemize/internal/domain/matcher"

--- a/internal/application/sync/handlers/walmart.go
+++ b/internal/application/sync/handlers/walmart.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	walmartprovider "github.com/eshaffer321/itemize/internal/adapters/providers/walmart"
 	"github.com/eshaffer321/itemize/internal/domain/categorizer"

--- a/internal/application/sync/handlers/walmart_test.go
+++ b/internal/application/sync/handlers/walmart_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/eshaffer321/itemize/internal/domain/categorizer"
 	"github.com/eshaffer321/itemize/internal/domain/matcher"

--- a/internal/application/sync/orchestrator.go
+++ b/internal/application/sync/orchestrator.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/eshaffer321/itemize/internal/application/sync/handlers"
 	"github.com/eshaffer321/itemize/internal/domain/categorizer"

--- a/internal/application/sync/orchestrator_process_test.go
+++ b/internal/application/sync/orchestrator_process_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/application/sync/orchestrator_test.go
+++ b/internal/application/sync/orchestrator_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"

--- a/internal/application/sync/process_order_test.go
+++ b/internal/application/sync/process_order_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/eshaffer321/itemize/internal/application/sync/handlers"
 	"github.com/eshaffer321/itemize/internal/domain/categorizer"

--- a/internal/application/sync/recording.go
+++ b/internal/application/sync/recording.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/eshaffer321/itemize/internal/application/sync/handlers"
 	"github.com/eshaffer321/itemize/internal/infrastructure/storage"

--- a/internal/application/sync/types.go
+++ b/internal/application/sync/types.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/clients"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/eshaffer321/itemize/internal/application/sync/handlers"

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/clients"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/eshaffer321/itemize/internal/api"

--- a/internal/domain/matcher/matcher.go
+++ b/internal/domain/matcher/matcher.go
@@ -20,7 +20,7 @@ package matcher
 import (
 	"math"
 
-	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 )
 

--- a/internal/domain/matcher/matcher_test.go
+++ b/internal/domain/matcher/matcher_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/internal/domain/matcher/multi.go
+++ b/internal/domain/matcher/multi.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 )
 

--- a/internal/domain/matcher/multi_test.go
+++ b/internal/domain/matcher/multi_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/domain/matcher/subset.go
+++ b/internal/domain/matcher/subset.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 )
 

--- a/internal/domain/matcher/types.go
+++ b/internal/domain/matcher/types.go
@@ -1,7 +1,7 @@
 package matcher
 
 import (
-	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 )
 
 // Config holds matcher configuration

--- a/internal/domain/splitter/splitter.go
+++ b/internal/domain/splitter/splitter.go
@@ -6,7 +6,7 @@ import (
 	"math"
 	"strings"
 
-	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/eshaffer321/itemize/internal/domain/categorizer"
 )

--- a/internal/domain/splitter/splitter_test.go
+++ b/internal/domain/splitter/splitter_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/eshaffer321/monarchmoney-go/pkg/monarch"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/eshaffer321/itemize/internal/domain/categorizer"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
## Summary
- Bumps the Monarch Go client dependency from `github.com/eshaffer321/monarchmoney-go v1.0.5` to `github.com/eshaffer321/monarch-go/v2 v2.0.0`, following its rename/rebrand from "MonarchMoney" to "Monarch"
- Updates all `pkg/monarch` import paths accordingly (mechanical, no logic changes)

## Compatibility notes
Checked the CHANGELOG between v1.0.5 and v2.0.0 against itemize's actual usage
(`Transactions.Get/Update/UpdateSplits/Delete/Query`, `Categories().List`). The only
breaking/behavioral changes in that range affect `Transactions.Create` and the holdings
APIs, neither of which itemize calls, so this should be a drop-in bump.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -race` — all packages pass