### PR TITLE
chore: enable Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` so Dependabot watches `go.mod` (gomod ecosystem) and `.github/workflows/*` (github-actions ecosystem) weekly and opens bump PRs automatically.
- Enabled vulnerability alerts and Dependabot security updates at the repo level (via API) — previously both were off, so Dependabot wasn't active in any capacity.
- Prompted by wanting `walmart-client-go` v2.0.2 to be picked up automatically; without this config, Dependabot never watches Go module versions at all.

## Test plan
- [x] Verified `.github/dependabot.yml` is valid YAML with the correct ecosystem/schedule fields
- [x] Confirmed via `gh api` that vulnerability alerts and automated security fixes are now enabled on the repo