### PR TITLE
feat: add -account and -list-accounts flags for Amazon

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,20 @@ BROWSER_DATA_DIR="$HOME/.itemize/amazon" amazon-scraper --login  # authenticate 
 BROWSER_DATA_DIR="$HOME/.itemize/amazon" amazon-scraper --login --profile "$AMAZON_ACCOUNT_NAME"
 ```
 
+#### Multiple Amazon accounts
+
+If you sync more than one Amazon account, use `-account` to pick a profile per run instead of
+setting `AMAZON_ACCOUNT_NAME` (useful for one-off manual runs where you don't want to remember
+an env var, or for cron jobs where the account name should be visible right in the crontab line):
+
+```bash
+./itemize amazon -list-accounts        # see which profiles you've logged into
+./itemize amazon -account amazon-wife  # sync a specific account
+```
+
+`AMAZON_ACCOUNT_NAME` still works and is used as the default when `-account` is omitted — cron
+jobs relying on the env var need no changes.
+
 ## Troubleshooting
 
 **"No matching transaction found"**

--- a/cmd/itemize/main.go
+++ b/cmd/itemize/main.go
@@ -59,6 +59,29 @@ func main() {
 	// Load config
 	cfg := config.LoadOrEnv()
 
+	if flags.ListAccounts {
+		if providerName != "amazon" {
+			fmt.Printf("-list-accounts is only supported for the amazon provider\n")
+			os.Exit(1)
+		}
+		accounts, err := cli.ListAmazonAccounts(cfg)
+		if err != nil {
+			log.Fatalf("Failed to list Amazon accounts: %v", err)
+		}
+		if len(accounts) == 0 {
+			fmt.Println("No saved Amazon accounts found.")
+			fmt.Println("Run 'amazon-scraper --login --profile <name>' to create one.")
+			return
+		}
+		fmt.Println("Saved Amazon accounts:")
+		for _, account := range accounts {
+			fmt.Printf("  %s\n", account)
+		}
+		fmt.Println()
+		fmt.Println("Use with: itemize amazon -account <name>")
+		return
+	}
+
 	// Initialize shared dependencies
 	serviceClients, err := clients.NewClients(cfg)
 	if err != nil {
@@ -83,7 +106,7 @@ func main() {
 	case "walmart":
 		provider, err = cli.NewWalmartProvider(cfg, flags.Verbose)
 	case "amazon":
-		provider, err = cli.NewAmazonProvider(cfg, flags.Verbose)
+		provider, err = cli.NewAmazonProvider(cfg, flags.Verbose, flags.Account)
 	default:
 		fmt.Printf("Unknown provider: %s\n", providerName)
 		printUsage()
@@ -101,8 +124,19 @@ func main() {
 	// Print database info
 	fmt.Printf("Database: %s\n", cfg.Storage.DatabasePath)
 
-	// Print configuration
-	cli.PrintConfiguration(provider.DisplayName(), flags.LookbackDays, flags.MaxOrders, flags.Force)
+	// Print configuration (shows the resolved Amazon account, if any, so it's
+	// obvious which profile is in use without digging through env vars)
+	resolvedAccount := ""
+	if providerName == "amazon" {
+		resolvedAccount = flags.Account
+		if resolvedAccount == "" {
+			resolvedAccount = cfg.Providers.Amazon.AccountName
+		}
+		if resolvedAccount == "" {
+			resolvedAccount = "default"
+		}
+	}
+	cli.PrintConfiguration(provider.DisplayName(), flags.LookbackDays, flags.MaxOrders, flags.Force, resolvedAccount)
 
 	// Create orchestrator with sync-scoped logger and run
 	opts := flags.ToSyncOptions()
@@ -145,6 +179,8 @@ func printUsage() {
 	fmt.Println("  -force           Force reprocess already processed orders")
 	fmt.Println("  -verbose         Verbose output")
 	fmt.Println("  -order-id string Process only this specific order ID (limits blast radius)")
+	fmt.Println("  -account string  Amazon account/profile name (amazon only)")
+	fmt.Println("  -list-accounts   List saved Amazon account profiles and exit (amazon only)")
 	fmt.Println()
 	fmt.Println("Environment Variables:")
 	fmt.Println("  MONARCH_TOKEN              Monarch API token (required)")

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -16,6 +16,8 @@ type SyncFlags struct {
 	Force        bool
 	Verbose      bool
 	OrderID      string
+	Account      string
+	ListAccounts bool
 }
 
 // ParseSyncFlags parses common sync flags from command line
@@ -27,6 +29,8 @@ func ParseSyncFlags() SyncFlags {
 	flag.BoolVar(&flags.Force, "force", false, "Force reprocess already processed orders")
 	flag.BoolVar(&flags.Verbose, "verbose", false, "Verbose output")
 	flag.StringVar(&flags.OrderID, "order-id", "", "Process only this specific order ID (limits blast radius)")
+	flag.StringVar(&flags.Account, "account", "", "Amazon account/profile name (overrides AMAZON_ACCOUNT_NAME; run -list-accounts to see saved profiles)")
+	flag.BoolVar(&flags.ListAccounts, "list-accounts", false, "List saved Amazon account profiles and exit")
 
 	flag.Usage = func() {
 		fmt.Fprintln(os.Stderr, "Usage: itemize <command> [flags]")

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -17,9 +17,13 @@ func PrintHeader(providerName string, dryRun bool) {
 	fmt.Printf("itemize: %s (%s mode)\n", providerName, mode)
 }
 
-// PrintConfiguration prints sync configuration
-func PrintConfiguration(providerName string, lookbackDays, maxOrders int, force bool) {
+// PrintConfiguration prints sync configuration. account is the resolved
+// Amazon profile name; pass "" for providers without multi-account support.
+func PrintConfiguration(providerName string, lookbackDays, maxOrders int, force bool, account string) {
 	fmt.Printf("Provider: %s | Lookback: %d days", providerName, lookbackDays)
+	if account != "" {
+		fmt.Printf(" | Account: %s", account)
+	}
 	if maxOrders > 0 {
 		fmt.Printf(" | Max orders: %d", maxOrders)
 	}

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -74,8 +74,10 @@ func NewWalmartProvider(cfg *config.Config, verbose bool) (providers.OrderProvid
 }
 
 // NewAmazonProvider creates a new Amazon provider with a system-scoped logger
-// Uses the amazon-order-scraper CLI (npm package) for fetching orders
-func NewAmazonProvider(cfg *config.Config, verbose bool) (providers.OrderProvider, error) {
+// Uses the amazon-order-scraper CLI (npm package) for fetching orders.
+// account, if non-empty, overrides cfg.Providers.Amazon.AccountName (and thus
+// AMAZON_ACCOUNT_NAME) — it's the value of the -account flag.
+func NewAmazonProvider(cfg *config.Config, verbose bool, account string) (providers.OrderProvider, error) {
 	// Create an amazon-scoped logger with verbose flag
 	loggingCfg := cfg.Observability.Logging
 	if verbose {
@@ -88,14 +90,45 @@ func NewAmazonProvider(cfg *config.Config, verbose bool) (providers.OrderProvide
 		return nil, err
 	}
 
+	profile := cfg.Providers.Amazon.AccountName
+	if account != "" {
+		profile = account
+	}
+
 	// Build provider config
 	providerCfg := &amazonprovider.ProviderConfig{
-		Profile:        cfg.Providers.Amazon.AccountName,
+		Profile:        profile,
 		Headless:       false, // Default to non-headless for interactive use
 		BrowserDataDir: browserDataDir,
 	}
 
 	return amazonprovider.NewProvider(amazonLogger, providerCfg), nil
+}
+
+// ListAmazonAccounts returns the names of saved Amazon browser profiles found
+// under the resolved browser data directory (each profile is a subdirectory
+// created the first time `amazon-scraper --login --profile <name>` runs).
+func ListAmazonAccounts(cfg *config.Config) ([]string, error) {
+	browserDataDir, err := resolveAmazonBrowserDataDir(cfg.Providers.Amazon.BrowserDataDir)
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := os.ReadDir(browserDataDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read browser data directory: %w", err)
+	}
+
+	var accounts []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			accounts = append(accounts, entry.Name())
+		}
+	}
+	return accounts, nil
 }
 
 func resolveAmazonBrowserDataDir(configured string) (string, error) {

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -1,0 +1,38 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/eshaffer321/itemize/internal/infrastructure/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListAmazonAccounts_ReturnsSubdirectoryNames(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "amazon-wife"), 0o700))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "amazon-me"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "not-a-profile.txt"), []byte("x"), 0o600))
+
+	cfg := &config.Config{}
+	cfg.Providers.Amazon.BrowserDataDir = dir
+
+	accounts, err := ListAmazonAccounts(cfg)
+	require.NoError(t, err)
+
+	sort.Strings(accounts)
+	assert.Equal(t, []string{"amazon-me", "amazon-wife"}, accounts, "should list only directories, not files")
+}
+
+func TestListAmazonAccounts_MissingDirReturnsEmptyNotError(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Providers.Amazon.BrowserDataDir = filepath.Join(t.TempDir(), "does-not-exist")
+
+	accounts, err := ListAmazonAccounts(cfg)
+
+	require.NoError(t, err, "a browser data dir that was never created is a normal first-run state, not an error")
+	assert.Empty(t, accounts)
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -66,7 +66,7 @@ func RunServe(cfg *config.Config, flags *ServeFlags) error {
 				return NewCostcoProvider(c, verbose)
 			},
 			"amazon": func(c *config.Config, verbose bool) (providers.OrderProvider, error) {
-				return NewAmazonProvider(c, verbose)
+				return NewAmazonProvider(c, verbose, "")
 			},
 		}
 


### PR DESCRIPTION
## Summary

`AMAZON_ACCOUNT_NAME` worked but was poor UX for two real usage patterns:
- **Manual one-off runs**: you have to remember the env var and the exact profile name, usually by digging through shell history — unlike `./itemize walmart`/`./itemize costco`, which need no extra state.
- **Cron jobs**: the account name is hidden in an env var assignment rather than visible in the command itself.

## Changes
- `-account <name>` flag — overrides `AMAZON_ACCOUNT_NAME` for a single run (amazon only)
- `-list-accounts` flag — scans the browser data directory (`~/.itemize/amazon` by default) and lists saved profiles, so you don't have to remember exact names:
  ```
  $ ./itemize amazon -list-accounts
  Saved Amazon accounts:
    amazon-erick
    amazon-sarah
    amazon-wife
    default

  Use with: itemize amazon -account <name>
  ```
- The resolved account now prints in the run header (`Provider: Amazon | Lookback: 14 days | Account: amazon-wife`) so it's never ambiguous which profile a run used
- `AMAZON_ACCOUNT_NAME` still works unchanged as the fallback default — existing cron jobs need no changes
- README documents the new flags under a "Multiple Amazon accounts" section

## Files changed
- `internal/cli/flags.go` — new flags
- `internal/cli/providers.go` — `NewAmazonProvider` takes an account override; new `ListAmazonAccounts`
- `internal/cli/providers_test.go` — new tests for `ListAmazonAccounts`
- `internal/cli/output.go` — `PrintConfiguration` shows the resolved account
- `internal/cli/serve.go` — updated call site for the new `NewAmazonProvider` signature (API server path unaffected, always uses config default)
- `cmd/itemize/main.go` — wires `-list-accounts` short-circuit and passes `-account` through
- `README.md` — usage docs

## Verification
- `go build ./...`, `go vet ./...`, `go test ./... -race` all pass
- Manually ran `./itemize amazon -list-accounts` against real local profiles, confirmed correct output
- Manually confirmed `-list-accounts` on `walmart`/`costco` exits with a clear error instead of silently doing nothing