### PR TITLE
fix: skip codecov upload for dependabot prs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           go tool cover -func=coverage.txt
 
       - name: Upload coverage reports to Codecov
-        if: matrix.go-version == '1.25.11'
+        if: matrix.go-version == '1.25.11' && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]')
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/docs/bug-fixes.md
+++ b/docs/bug-fixes.md
@@ -12,6 +12,30 @@ Each bug fix entry should include:
 
 ## Bug Fixes
 
+### 2026-07-02: Dependabot PR tests failed because Codecov upload required a token
+
+**Description:**
+Dependabot PRs showed the `Test` CI job as failed even when the Go test command passed. The failure came from the Codecov upload step, which ran with `fail_ci_if_error: true` but did not receive `CODECOV_TOKEN` on Dependabot pull requests, causing Codecov to return `Token required because branch is protected`.
+
+**Test Case:**
+```go
+// internal/ci/workflow_test.go: TestCodecovUploadSkippedForDependabotPRs
+// Expected: the Codecov upload step is guarded so Dependabot pull requests skip it.
+// Actual before fix: the step only checked matrix.go-version and ran on Dependabot PRs.
+```
+
+**Root Cause:**
+The workflow treated coverage upload as part of the `Test` job for every pull request. Dependabot PRs do not have the normal repository secret available for Codecov token-authenticated uploads, so an auxiliary reporting step made the test job look red despite passing tests.
+
+**Fix Applied:**
+Updated `.github/workflows/ci.yml` so the Codecov upload step still runs on pushes and normal PRs, but skips pull requests opened by `dependabot[bot]`.
+
+**Verification:**
+- `TestCodecovUploadSkippedForDependabotPRs` failed before the workflow change and passes after.
+- `go test ./...` passes.
+
+---
+
 ### 2026-07-01: Release binaries would panic on startup — cgo sqlite driver incompatible with cross-compiled builds
 
 **Description:**

--- a/internal/ci/workflow_test.go
+++ b/internal/ci/workflow_test.go
@@ -1,0 +1,79 @@
+package ci_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type workflow struct {
+	Jobs map[string]job `yaml:"jobs"`
+}
+
+type job struct {
+	Steps []step `yaml:"steps"`
+}
+
+type step struct {
+	Name string `yaml:"name"`
+	If   string `yaml:"if"`
+	Uses string `yaml:"uses"`
+}
+
+func TestCodecovUploadSkippedForDependabotPRs(t *testing.T) {
+	root := repoRoot(t)
+	data, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "ci.yml"))
+	if err != nil {
+		t.Fatalf("read ci workflow: %v", err)
+	}
+
+	var ci workflow
+	if err := yaml.Unmarshal(data, &ci); err != nil {
+		t.Fatalf("parse ci workflow: %v", err)
+	}
+
+	testJob, ok := ci.Jobs["test"]
+	if !ok {
+		t.Fatal("ci workflow is missing the test job")
+	}
+
+	var codecovStep *step
+	for i := range testJob.Steps {
+		if testJob.Steps[i].Name == "Upload coverage reports to Codecov" {
+			codecovStep = &testJob.Steps[i]
+			break
+		}
+	}
+	if codecovStep == nil {
+		t.Fatal("test job is missing the Codecov upload step")
+	}
+	if !strings.Contains(codecovStep.Uses, "codecov/codecov-action") {
+		t.Fatalf("Codecov step uses %q, want codecov/codecov-action", codecovStep.Uses)
+	}
+	if !strings.Contains(codecovStep.If, "github.event_name != 'pull_request'") ||
+		!strings.Contains(codecovStep.If, "dependabot[bot]") {
+		t.Fatalf("Codecov upload should be skipped for Dependabot PRs, got if: %q", codecovStep.If)
+	}
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find repo root from test working directory")
+		}
+		dir = parent
+	}
+}


### PR DESCRIPTION
## Summary
- skip Codecov upload on Dependabot pull requests so the Test job reflects actual Go test results
- add a regression test for the CI workflow guard
- document the CI bug fix

## Verification
- go test ./internal/ci -run TestCodecovUploadSkippedForDependabotPRs -v
- go test ./...