### PR TITLE
fix: preserve sync audit history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main, develop ]
 
 env:
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
 
 jobs:
   lint:
@@ -72,7 +72,7 @@ jobs:
     needs: [module-integrity]
     strategy:
       matrix:
-        go-version: ['1.25.11']
+        go-version: ['1.25.12']
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -92,7 +92,7 @@ jobs:
           go tool cover -func=coverage.txt
 
       - name: Upload coverage reports to Codecov
-        if: matrix.go-version == '1.25.11' && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]')
+        if: matrix.go-version == '1.25.12' && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]')
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
 
 jobs:
   test:

--- a/docs/bug-fixes.md
+++ b/docs/bug-fixes.md
@@ -12,6 +12,36 @@ Each bug fix entry should include:
 
 ## Bug Fixes
 
+### 2026-07-08: Costco split success could be overwritten by later no-match failure
+
+**Description:**
+A Costco receipt could mutate Monarch successfully, then later appear in SQLite as `failed: no matching transaction found`. After Monarch splits a parent transaction, the original one-row `$total` transaction may no longer be visible to the simple exact matcher, and a retry could replace the local success summary with a failed row. That destroyed the audit trail needed to prove what happened.
+
+**Test Case:**
+```go
+// internal/infrastructure/storage/storage_test.go: TestStorage_SaveRecord_DoesNotDowngradeSuccessWithFailure
+// Expected: a later failed retry cannot overwrite an existing non-dry-run success summary.
+
+// internal/infrastructure/storage/storage_test.go: TestStorage_SaveRecord_AppendsAttemptHistory
+// Expected: both the original success and later failure remain queryable in processing_attempts.
+
+// internal/application/sync/handlers/simple_test.go: TestSimpleHandler_ProcessOrder_ReconcilesAlreadySplitTransactions
+// Expected: if same-day Costco rows sum to the receipt total and notes match receipt items,
+// itemize records the order as already processed instead of reporting no match.
+```
+
+**Root Cause:**
+`processing_records` was a single mutable row per order and `SaveRecord` used `INSERT OR REPLACE`. Normal handler mutations (`UpdateTransaction` and `UpdateSplits`) were not logged in `api_calls`, and failure records did not store the same raw order/debug payload as success records. The system could therefore reach a split/updated state in Monarch while retaining only a later failed local summary.
+
+**Fix Applied:**
+Added append-only `processing_attempts`, `order_transactions`, match diagnostics, and mutation metadata. `SaveRecord` now appends every attempt and refuses to downgrade an existing real success to failed/pending. Failure and pending records now include raw order audit data. The Monarch adapter logs all transaction updates/split updates, and the simple handler can reconcile already-split Costco-style rows before emitting a no-match failure.
+
+**Verification:**
+- `go test ./internal/infrastructure/storage ./internal/application/sync/handlers ./internal/application/sync -run 'TestStorage_SaveRecord_DoesNotDowngradeSuccessWithFailure|TestStorage_SaveRecord_AppendsAttemptHistory|TestStorage_OrderTransactions_MultipleRowsPerOrder|TestSimpleHandler_ProcessOrder_ReconcilesAlreadySplitTransactions|TestMonarchAdapter_LogAPICallIncludesOrderAndTransaction' -count=1` passes.
+- `go test ./...` passes.
+
+---
+
 ### 2026-07-02: Dependabot PR tests failed because Codecov upload required a token
 
 **Description:**

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/eshaffer321/itemize
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/eshaffer321/amazon-go v0.3.0

--- a/internal/application/sync/handlers/amazon.go
+++ b/internal/application/sync/handlers/amazon.go
@@ -98,6 +98,10 @@ type ProcessResult struct {
 	CategoryID   string // Category ID assigned (for single-category updates)
 	CategoryName string // Human-readable category name
 	MonarchNotes string // Notes sent to Monarch
+
+	// Debug/reconciliation audit fields
+	MatchDiagnosticsJSON   string
+	ReconciledTransactions []*monarch.Transaction
 }
 
 // AmazonHandler processes Amazon orders with pro-rata allocation

--- a/internal/application/sync/handlers/simple.go
+++ b/internal/application/sync/handlers/simple.go
@@ -2,15 +2,16 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"math"
 	"strings"
 
-	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/eshaffer321/itemize/internal/domain/categorizer"
 	"github.com/eshaffer321/itemize/internal/domain/matcher"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 )
 
 // SimpleHandler processes orders for simple providers like Costco
@@ -57,6 +58,23 @@ func (h *SimpleHandler) ProcessOrder(
 	}
 
 	if matchResult == nil {
+		diagnostics := buildSimpleMatchDiagnostics(order, monarchTxns, usedTxnIDs)
+		result.MatchDiagnosticsJSON = diagnostics
+		if reconciled := h.findAlreadySplitTransactions(order, monarchTxns, usedTxnIDs); len(reconciled) > 0 {
+			for _, tx := range reconciled {
+				usedTxnIDs[tx.ID] = true
+			}
+			result.Processed = true
+			result.Transaction = reconciled[0]
+			result.ReconciledTransactions = reconciled
+			result.MonarchNotes = "Reconciled already-split Monarch transactions"
+			h.logWarn("Order already appears split in Monarch",
+				"order_id", order.GetID(),
+				"transaction_count", len(reconciled),
+				"expected_amount", order.GetTotal())
+			return result, nil
+		}
+
 		result.Skipped = true
 		result.SkipReason = "no matching transaction found"
 		h.logWarn("No matching transaction found", "order_id", order.GetID())
@@ -194,6 +212,109 @@ func (h *SimpleHandler) applyMultiCategorySplits(
 	result.Transaction = transaction
 	result.Processed = true
 	return result, nil
+}
+
+type simpleMatchCandidate struct {
+	ID         string  `json:"id"`
+	Date       string  `json:"date"`
+	Amount     float64 `json:"amount"`
+	AmountDiff float64 `json:"amount_diff"`
+	DateDiff   float64 `json:"date_diff_days"`
+	Used       bool    `json:"used"`
+	HasSplits  bool    `json:"has_splits"`
+	Reason     string  `json:"reason"`
+}
+
+type simpleMatchDiagnostics struct {
+	OrderID        string                 `json:"order_id"`
+	OrderDate      string                 `json:"order_date"`
+	ExpectedAmount float64                `json:"expected_amount"`
+	CandidateCount int                    `json:"candidate_count"`
+	Candidates     []simpleMatchCandidate `json:"candidates"`
+}
+
+func buildSimpleMatchDiagnostics(order providers.Order, txns []*monarch.Transaction, usedTxnIDs map[string]bool) string {
+	const dateTolerance = 5.0
+	const amountTolerance = 0.01
+
+	diagnostics := simpleMatchDiagnostics{
+		OrderID:        order.GetID(),
+		OrderDate:      order.GetDate().Format("2006-01-02"),
+		ExpectedAmount: order.GetTotal(),
+		CandidateCount: len(txns),
+		Candidates:     make([]simpleMatchCandidate, 0, len(txns)),
+	}
+
+	for _, tx := range txns {
+		dateDiff := math.Abs(tx.Date.Time.Sub(order.GetDate()).Hours() / 24)
+		amountDiff := math.Abs(math.Abs(tx.Amount) - math.Abs(order.GetTotal()))
+		candidate := simpleMatchCandidate{
+			ID:         tx.ID,
+			Date:       tx.Date.Format("2006-01-02"),
+			Amount:     tx.Amount,
+			AmountDiff: amountDiff,
+			DateDiff:   dateDiff,
+			Used:       usedTxnIDs[tx.ID],
+			HasSplits:  tx.HasSplits,
+			Reason:     "candidate",
+		}
+		switch {
+		case candidate.Used:
+			candidate.Reason = "already_used"
+		case tx.Amount > 0 && order.GetTotal() > 0:
+			candidate.Reason = "wrong_sign"
+		case dateDiff > dateTolerance:
+			candidate.Reason = "date_out_of_range"
+		case amountDiff > amountTolerance:
+			candidate.Reason = "amount_mismatch"
+		}
+		diagnostics.Candidates = append(diagnostics.Candidates, candidate)
+	}
+
+	data, err := json.Marshal(diagnostics)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+func (h *SimpleHandler) findAlreadySplitTransactions(order providers.Order, txns []*monarch.Transaction, usedTxnIDs map[string]bool) []*monarch.Transaction {
+	matches, err := h.matcher.FindSubsetByTotal(order, txns, usedTxnIDs)
+	if err != nil || len(matches) < 2 {
+		return nil
+	}
+	if !notesMatchOrderItems(matches, order.GetItems()) {
+		return nil
+	}
+	return matches
+}
+
+func notesMatchOrderItems(txns []*monarch.Transaction, items []providers.OrderItem) bool {
+	if len(items) == 0 {
+		return false
+	}
+
+	notes := strings.Builder{}
+	for _, tx := range txns {
+		notes.WriteString(" ")
+		notes.WriteString(strings.ToUpper(tx.Notes))
+	}
+	joinedNotes := notes.String()
+	if strings.TrimSpace(joinedNotes) == "" {
+		return false
+	}
+
+	matches := 0
+	for _, item := range items {
+		name := strings.ToUpper(strings.TrimSpace(item.GetName()))
+		if len(name) < 4 {
+			continue
+		}
+		if strings.Contains(joinedNotes, name) {
+			matches++
+		}
+	}
+	return matches >= 1
 }
 
 // Nil-safe logging helpers

--- a/internal/application/sync/handlers/simple_test.go
+++ b/internal/application/sync/handlers/simple_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/eshaffer321/itemize/internal/domain/categorizer"
 	"github.com/eshaffer321/itemize/internal/domain/matcher"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -183,6 +183,55 @@ func TestSimpleHandler_ProcessOrder_NoMatch_Skipped(t *testing.T) {
 	assert.False(t, result.Processed)
 	assert.True(t, result.Skipped)
 	assert.Contains(t, result.SkipReason, "no matching transaction")
+}
+
+func TestSimpleHandler_ProcessOrder_ReconcilesAlreadySplitTransactions(t *testing.T) {
+	splitter := &simpleTestSplitter{}
+	monarchClient := &simpleTestMonarch{}
+	handler := createTestSimpleHandler(t, splitter, monarchClient)
+
+	orderDate := time.Now()
+	order := &simpleTestOrder{
+		id:           "ORDER-RECONCILE",
+		date:         orderDate,
+		total:        307.79,
+		subtotal:     290.37,
+		tax:          17.42,
+		providerName: "Costco",
+		items: []providers.OrderItem{
+			&simpleTestItem{name: "CANTALOUPE", price: 6.99, quantity: 1},
+			&simpleTestItem{name: "HYDRORAIL", price: 99.97, quantity: 1},
+			&simpleTestItem{name: "KSDIAPER SZ5", price: 39.99, quantity: 1},
+			&simpleTestItem{name: "HOTO SCRUB", price: 29.99, quantity: 1},
+		},
+	}
+
+	transactions := []*monarch.Transaction{
+		{ID: "txn-grocery", Amount: -127.64, Date: simpleToMonarchDate(orderDate), Notes: "Groceries:\n- CANTALOUPE $6.99"},
+		{ID: "txn-home", Amount: -105.97, Date: simpleToMonarchDate(orderDate), Notes: "Home Spending:\n- HYDRORAIL $99.97"},
+		{ID: "txn-kids", Amount: -42.39, Date: simpleToMonarchDate(orderDate), Notes: "Kid Needs:\n- KSDIAPER SZ5 $39.99"},
+		{ID: "txn-house", Amount: -31.79, Date: simpleToMonarchDate(orderDate), Notes: "Household Supplies:\n- HOTO SCRUB $29.99"},
+	}
+
+	usedTxnIDs := make(map[string]bool)
+	result, err := handler.ProcessOrder(
+		context.Background(),
+		order,
+		transactions,
+		usedTxnIDs,
+		nil,
+		nil,
+		false,
+	)
+
+	require.NoError(t, err)
+	assert.True(t, result.Processed)
+	assert.False(t, result.Skipped)
+	require.Len(t, result.ReconciledTransactions, 4)
+	assert.False(t, monarchClient.updateCalled)
+	assert.False(t, monarchClient.updateSplitsCaled)
+	assert.True(t, usedTxnIDs["txn-grocery"])
+	assert.NotEmpty(t, result.MatchDiagnosticsJSON)
 }
 
 func TestSimpleHandler_ProcessOrder_TransactionAlreadyHasSplits_Skipped(t *testing.T) {

--- a/internal/application/sync/orchestrator.go
+++ b/internal/application/sync/orchestrator.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/eshaffer321/itemize/internal/application/sync/handlers"
 	"github.com/eshaffer321/itemize/internal/domain/categorizer"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 )
 
 // handleResult processes the result from a provider handler and records success/error
@@ -15,7 +15,7 @@ import (
 func (o *Orchestrator) handleResult(order providers.Order, result *handlers.ProcessResult, err error, opts Options) (bool, bool, error) {
 	if err != nil {
 		o.logger.Error("Handler error", "order_id", order.GetID(), "error", err)
-		o.recordError(order, err.Error())
+		o.recordError(order, err.Error(), nil)
 		return false, false, err
 	}
 	if result.Skipped {
@@ -31,7 +31,7 @@ func (o *Orchestrator) handleResult(order providers.Order, result *handlers.Proc
 			return false, true, nil
 		}
 		o.logger.Warn("Order skipped", "order_id", order.GetID(), "reason", result.SkipReason)
-		o.recordError(order, result.SkipReason)
+		o.recordError(order, result.SkipReason, result)
 		return false, false, fmt.Errorf("skipped: %s", result.SkipReason)
 	}
 	if result.Processed {
@@ -52,6 +52,8 @@ func (o *Orchestrator) processOrder(
 	monarchCategories []*monarch.TransactionCategory,
 	opts Options,
 ) (bool, bool, error) {
+	ctx = withAuditContext(ctx, order.GetID(), opts.DryRun)
+
 	o.logger.Debug("Processing order",
 		"order_id", order.GetID(),
 		"order_date", order.GetDate().Format("2006-01-02"),
@@ -135,6 +137,9 @@ func (o *Orchestrator) Run(ctx context.Context, opts Options) (*Result, error) {
 		}
 		if o.consolidator != nil {
 			o.consolidator.SetRunID(o.runID)
+		}
+		if o.monarchAdapter != nil {
+			o.monarchAdapter.runID = o.runID
 		}
 		// Set up ledger storage for Walmart handler
 		if o.walmartHandler != nil {

--- a/internal/application/sync/process_order_test.go
+++ b/internal/application/sync/process_order_test.go
@@ -7,12 +7,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/eshaffer321/itemize/internal/application/sync/handlers"
 	"github.com/eshaffer321/itemize/internal/domain/categorizer"
 	"github.com/eshaffer321/itemize/internal/domain/matcher"
 	"github.com/eshaffer321/itemize/internal/domain/splitter"
+	"github.com/eshaffer321/itemize/internal/infrastructure/storage"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -153,6 +154,33 @@ func createTestOrchestrator(t *testing.T) *Orchestrator {
 		simpleHandler: simpleHandler,
 		logger:        logger,
 	}
+}
+
+func TestMonarchAdapter_LogAPICallIncludesOrderAndTransaction(t *testing.T) {
+	store := storage.NewMockRepository()
+	adapter := &monarchAdapter{
+		storage: store,
+		runID:   42,
+	}
+
+	ctx := withAuditContext(context.Background(), "ORDER-AUDIT", false)
+	adapter.logAPICall(ctx, "txn-123", "Transactions.UpdateSplits",
+		map[string]any{"split_count": 2},
+		map[string]any{"ok": true},
+		nil,
+		150*time.Millisecond,
+	)
+
+	calls, err := store.GetAPICallsByOrderID("ORDER-AUDIT")
+	require.NoError(t, err)
+	require.Len(t, calls, 1)
+	assert.Equal(t, int64(42), calls[0].RunID)
+	assert.Equal(t, "ORDER-AUDIT", calls[0].OrderID)
+	assert.Equal(t, "txn-123", calls[0].TransactionID)
+	assert.Equal(t, "Transactions.UpdateSplits", calls[0].Method)
+	assert.Equal(t, int64(150), calls[0].DurationMs)
+	assert.False(t, calls[0].DryRun)
+	assert.Contains(t, calls[0].RequestJSON, "split_count")
 }
 
 // =============================================================================

--- a/internal/application/sync/recording.go
+++ b/internal/application/sync/recording.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/eshaffer321/itemize/internal/application/sync/handlers"
 	"github.com/eshaffer321/itemize/internal/infrastructure/storage"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 )
 
 // convertOrderItems converts provider order items to storage order items
@@ -50,9 +50,10 @@ func convertSplits(splits []*monarch.TransactionSplit) []storage.SplitDetail {
 // These handle persisting processing results and API call logs to storage.
 
 // recordError records a processing error to storage
-func (o *Orchestrator) recordError(order providers.Order, errorMsg string) {
+func (o *Orchestrator) recordError(order providers.Order, errorMsg string, result *handlers.ProcessResult) {
 	if o.storage != nil {
 		record := &storage.ProcessingRecord{
+			RunID:         o.runID,
 			OrderID:       order.GetID(),
 			Provider:      order.GetProviderName(),
 			OrderDate:     order.GetDate(),
@@ -66,6 +67,13 @@ func (o *Orchestrator) recordError(order providers.Order, errorMsg string) {
 			ErrorMessage:  errorMsg,
 			Items:         convertOrderItems(order.GetItems()),
 		}
+		if result != nil {
+			record.MatchDiagnosticsJSON = result.MatchDiagnosticsJSON
+			record.CategoryID = result.CategoryID
+			record.CategoryName = result.CategoryName
+			record.MonarchNotes = result.MonarchNotes
+		}
+		o.populateRecordAudit(order, record)
 		if err := o.storage.SaveRecord(record); err != nil {
 			o.logger.Error("Failed to save error record", "order_id", order.GetID(), "error", err)
 		}
@@ -77,6 +85,7 @@ func (o *Orchestrator) recordError(order providers.Order, errorMsg string) {
 func (o *Orchestrator) recordPending(order providers.Order, reason string) {
 	if o.storage != nil {
 		record := &storage.ProcessingRecord{
+			RunID:         o.runID,
 			OrderID:       order.GetID(),
 			Provider:      order.GetProviderName(),
 			OrderDate:     order.GetDate(),
@@ -90,6 +99,7 @@ func (o *Orchestrator) recordPending(order providers.Order, reason string) {
 			ErrorMessage:  reason,
 			Items:         convertOrderItems(order.GetItems()),
 		}
+		o.populateRecordAudit(order, record)
 		if err := o.storage.SaveRecord(record); err != nil {
 			o.logger.Error("Failed to save pending record", "order_id", order.GetID(), "error", err)
 		}
@@ -108,6 +118,7 @@ func (o *Orchestrator) recordSuccessWithResult(
 ) {
 	if o.storage != nil {
 		record := &storage.ProcessingRecord{
+			RunID:           o.runID,
 			OrderID:         order.GetID(),
 			Provider:        order.GetProviderName(),
 			OrderDate:       order.GetDate(),
@@ -146,22 +157,67 @@ func (o *Orchestrator) recordSuccessWithResult(
 			record.CategoryID = result.CategoryID
 			record.CategoryName = result.CategoryName
 			record.MonarchNotes = result.MonarchNotes
-		}
-
-		// Serialize raw order data for audit trail
-		if rawData := order.GetRawData(); rawData != nil {
-			if rawJSON, err := json.Marshal(rawData); err == nil {
-				record.RawOrderJSON = string(rawJSON)
+			record.MatchDiagnosticsJSON = result.MatchDiagnosticsJSON
+			if len(result.ReconciledTransactions) > 0 {
+				record.SplitCount = len(result.ReconciledTransactions)
 			}
 		}
 
-		// Extract fees breakdown if available (provider-specific)
-		if feesData := extractFeesBreakdown(order); feesData != "" {
-			record.OrderFeesJSON = feesData
-		}
+		o.populateRecordAudit(order, record)
 
 		if err := o.storage.SaveRecord(record); err != nil {
 			o.logger.Error("Failed to save success record", "order_id", order.GetID(), "error", err)
+		}
+		o.recordOrderTransactions(order, record, result)
+	}
+}
+
+func (o *Orchestrator) populateRecordAudit(order providers.Order, record *storage.ProcessingRecord) {
+	if rawData := order.GetRawData(); rawData != nil {
+		if rawJSON, err := json.Marshal(rawData); err == nil {
+			record.RawOrderJSON = string(rawJSON)
+		}
+	}
+
+	if feesData := extractFeesBreakdown(order); feesData != "" {
+		record.OrderFeesJSON = feesData
+	}
+}
+
+func (o *Orchestrator) recordOrderTransactions(order providers.Order, record *storage.ProcessingRecord, result *handlers.ProcessResult) {
+	if o.storage == nil || result == nil {
+		return
+	}
+	if len(result.ReconciledTransactions) > 0 {
+		for _, txn := range result.ReconciledTransactions {
+			if txn == nil {
+				continue
+			}
+			if err := o.storage.SaveOrderTransaction(&storage.OrderTransaction{
+				RunID:         o.runID,
+				OrderID:       order.GetID(),
+				TransactionID: txn.ID,
+				Role:          "reconciled",
+				Amount:        txn.Amount,
+				Notes:         txn.Notes,
+			}); err != nil {
+				o.logger.Error("Failed to save reconciled order transaction", "order_id", order.GetID(), "transaction_id", txn.ID, "error", err)
+			}
+		}
+		return
+	}
+	if result.Transaction != nil {
+		if err := o.storage.SaveOrderTransaction(&storage.OrderTransaction{
+			RunID:         o.runID,
+			OrderID:       order.GetID(),
+			TransactionID: result.Transaction.ID,
+			Role:          "matched",
+			Amount:        result.Transaction.Amount,
+			CategoryID:    record.CategoryID,
+			CategoryName:  record.CategoryName,
+			Notes:         record.MonarchNotes,
+		}); err != nil {
+			o.logger.Error("Failed to save order transaction", "order_id", order.GetID(), "transaction_id", result.Transaction.ID, "error", err)
 		}
 	}
 }

--- a/internal/application/sync/types.go
+++ b/internal/application/sync/types.go
@@ -2,9 +2,10 @@ package sync
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
+	"time"
 
-	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 	"github.com/eshaffer321/itemize/internal/adapters/clients"
 	"github.com/eshaffer321/itemize/internal/adapters/providers"
 	"github.com/eshaffer321/itemize/internal/application/sync/handlers"
@@ -12,6 +13,7 @@ import (
 	"github.com/eshaffer321/itemize/internal/domain/matcher"
 	"github.com/eshaffer321/itemize/internal/domain/splitter"
 	"github.com/eshaffer321/itemize/internal/infrastructure/storage"
+	"github.com/eshaffer321/monarch-go/v2/pkg/monarch"
 )
 
 // ProgressUpdate represents a progress update during sync
@@ -55,6 +57,7 @@ type Orchestrator struct {
 	amazonHandler  *handlers.AmazonHandler
 	walmartHandler *handlers.WalmartHandler
 	simpleHandler  *handlers.SimpleHandler
+	monarchAdapter *monarchAdapter
 	storage        storage.Repository // Interface instead of concrete type
 	logger         *slog.Logger
 	runID          int64 // Current sync run ID for API logging
@@ -86,6 +89,15 @@ func NewOrchestrator(
 		consolidator = NewConsolidator(clients.Monarch, logger, store, 0)
 	}
 
+	var mAdapter *monarchAdapter
+	if clients != nil && clients.Monarch != nil {
+		mAdapter = &monarchAdapter{
+			client:  clients.Monarch,
+			storage: store,
+			logger:  logger,
+		}
+	}
+
 	// Create Amazon handler (if all dependencies available)
 	var amazonHandler *handlers.AmazonHandler
 	if clients != nil && clients.Monarch != nil && spl != nil && consolidator != nil {
@@ -93,7 +105,7 @@ func NewOrchestrator(
 			transactionMatcher,
 			&consolidatorAdapter{consolidator},
 			&splitterAdapter{spl},
-			&monarchAdapter{clients.Monarch},
+			mAdapter,
 			logger,
 		)
 	}
@@ -105,7 +117,7 @@ func NewOrchestrator(
 			transactionMatcher,
 			&consolidatorAdapter{consolidator},
 			&splitterAdapter{spl},
-			&monarchAdapter{clients.Monarch},
+			mAdapter,
 			logger,
 		)
 	}
@@ -116,7 +128,7 @@ func NewOrchestrator(
 		simpleHandler = handlers.NewSimpleHandler(
 			transactionMatcher,
 			&splitterAdapter{spl},
-			&monarchAdapter{clients.Monarch},
+			mAdapter,
 			logger,
 		)
 	}
@@ -130,6 +142,7 @@ func NewOrchestrator(
 		amazonHandler:  amazonHandler,
 		walmartHandler: walmartHandler,
 		simpleHandler:  simpleHandler,
+		monarchAdapter: mAdapter,
 		storage:        store,
 		logger:         logger,
 	}
@@ -166,16 +179,83 @@ func (a *splitterAdapter) GetSingleCategoryInfo(ctx context.Context, order provi
 
 // monarchAdapter wraps monarch.Client to implement handlers.MonarchClient
 type monarchAdapter struct {
-	client *monarch.Client
+	client  *monarch.Client
+	storage storage.Repository
+	logger  *slog.Logger
+	runID   int64
 }
 
 func (a *monarchAdapter) UpdateTransaction(ctx context.Context, id string, params *monarch.UpdateTransactionParams) error {
-	_, err := a.client.Transactions.Update(ctx, id, params)
+	start := time.Now()
+	updated, err := a.client.Transactions.Update(ctx, id, params)
+	a.logAPICall(ctx, id, "Transactions.Update", params, updated, err, time.Since(start))
 	return err
 }
 
 func (a *monarchAdapter) UpdateSplits(ctx context.Context, id string, splits []*monarch.TransactionSplit) error {
-	return a.client.Transactions.UpdateSplits(ctx, id, splits)
+	start := time.Now()
+	err := a.client.Transactions.UpdateSplits(ctx, id, splits)
+	response := map[string]any{"ok": err == nil, "split_count": len(splits)}
+	a.logAPICall(ctx, id, "Transactions.UpdateSplits", splits, response, err, time.Since(start))
+	return err
+}
+
+func (a *monarchAdapter) logAPICall(ctx context.Context, transactionID, method string, request, response any, callErr error, duration time.Duration) {
+	if a == nil || a.storage == nil {
+		return
+	}
+
+	requestJSON, _ := json.Marshal(request)
+	responseJSON, _ := json.Marshal(response)
+	errText := ""
+	if callErr != nil {
+		errText = callErr.Error()
+	}
+
+	call := &storage.APICall{
+		RunID:         a.runID,
+		OrderID:       auditOrderID(ctx),
+		TransactionID: transactionID,
+		Method:        method,
+		RequestJSON:   string(requestJSON),
+		ResponseJSON:  string(responseJSON),
+		Error:         errText,
+		DurationMs:    duration.Milliseconds(),
+		DryRun:        auditDryRun(ctx),
+	}
+	if err := a.storage.LogAPICall(call); err != nil && a.logger != nil {
+		a.logger.Warn("Failed to log Monarch API call",
+			"order_id", call.OrderID,
+			"transaction_id", transactionID,
+			"method", method,
+			"error", err)
+	}
+}
+
+type auditContextKey string
+
+const (
+	auditOrderIDKey auditContextKey = "order_id"
+	auditDryRunKey  auditContextKey = "dry_run"
+)
+
+func withAuditContext(ctx context.Context, orderID string, dryRun bool) context.Context {
+	ctx = context.WithValue(ctx, auditOrderIDKey, orderID)
+	return context.WithValue(ctx, auditDryRunKey, dryRun)
+}
+
+func auditOrderID(ctx context.Context) string {
+	if value, ok := ctx.Value(auditOrderIDKey).(string); ok {
+		return value
+	}
+	return ""
+}
+
+func auditDryRun(ctx context.Context) bool {
+	if value, ok := ctx.Value(auditDryRunKey).(bool); ok {
+		return value
+	}
+	return false
 }
 
 // ledgerStorageAdapter wraps storage.Repository to implement handlers.LedgerStorage

--- a/internal/infrastructure/storage/interfaces.go
+++ b/internal/infrastructure/storage/interfaces.go
@@ -16,6 +16,15 @@ type OrderRepository interface {
 	// SaveRecord saves or updates a processing record
 	SaveRecord(record *ProcessingRecord) error
 
+	// GetAttemptsByOrderID retrieves append-only attempts for an order.
+	GetAttemptsByOrderID(orderID string) ([]ProcessingAttempt, error)
+
+	// SaveOrderTransaction records a Monarch transaction associated with an order.
+	SaveOrderTransaction(txn *OrderTransaction) error
+
+	// GetOrderTransactions retrieves Monarch transaction associations for an order.
+	GetOrderTransactions(orderID string) ([]OrderTransaction, error)
+
 	// GetRecord retrieves a record by order ID
 	GetRecord(orderID string) (*ProcessingRecord, error)
 
@@ -54,12 +63,12 @@ type OrderListResult struct {
 
 // ItemSearchResult represents an item found in search
 type ItemSearchResult struct {
-	OrderID    string  `json:"order_id"`
-	Provider   string  `json:"provider"`
-	OrderDate  string  `json:"order_date"`
-	ItemName   string  `json:"item_name"`
-	ItemPrice  float64 `json:"item_price"`
-	Category   string  `json:"category,omitempty"`
+	OrderID   string  `json:"order_id"`
+	Provider  string  `json:"provider"`
+	OrderDate string  `json:"order_date"`
+	ItemName  string  `json:"item_name"`
+	ItemPrice float64 `json:"item_price"`
+	Category  string  `json:"category,omitempty"`
 }
 
 // SyncRunRepository handles sync run tracking
@@ -79,17 +88,17 @@ type SyncRunRepository interface {
 
 // SyncRun represents a sync run record
 type SyncRun struct {
-	ID              int64   `json:"id"`
-	Provider        string  `json:"provider"`
-	StartedAt       string  `json:"started_at"`
-	CompletedAt     string  `json:"completed_at,omitempty"`
-	LookbackDays    int     `json:"lookback_days"`
-	DryRun          bool    `json:"dry_run"`
-	OrdersFound     int     `json:"orders_found"`
-	OrdersProcessed int     `json:"orders_processed"`
-	OrdersSkipped   int     `json:"orders_skipped"`
-	OrdersErrored   int     `json:"orders_errored"`
-	Status          string  `json:"status"`
+	ID              int64  `json:"id"`
+	Provider        string `json:"provider"`
+	StartedAt       string `json:"started_at"`
+	CompletedAt     string `json:"completed_at,omitempty"`
+	LookbackDays    int    `json:"lookback_days"`
+	DryRun          bool   `json:"dry_run"`
+	OrdersFound     int    `json:"orders_found"`
+	OrdersProcessed int    `json:"orders_processed"`
+	OrdersSkipped   int    `json:"orders_skipped"`
+	OrdersErrored   int    `json:"orders_errored"`
+	Status          string `json:"status"`
 }
 
 // APICallRepository handles API call logging

--- a/internal/infrastructure/storage/migrations/00009_add_audit_attempts.sql
+++ b/internal/infrastructure/storage/migrations/00009_add_audit_attempts.sql
@@ -1,0 +1,93 @@
+-- +goose Up
+-- Durable debugging/audit trail for order processing.
+-- processing_records remains the latest summary row. processing_attempts is append-only.
+
+-- +goose StatementBegin
+ALTER TABLE processing_records ADD COLUMN match_diagnostics_json TEXT;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS processing_attempts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id INTEGER,
+    order_id TEXT NOT NULL,
+    provider TEXT,
+    transaction_id TEXT,
+    order_date TIMESTAMP,
+    processed_at TIMESTAMP,
+    order_total REAL,
+    order_subtotal REAL,
+    order_tax REAL,
+    order_tip REAL,
+    transaction_amount REAL,
+    split_count INTEGER,
+    status TEXT,
+    error_message TEXT,
+    item_count INTEGER,
+    match_confidence REAL,
+    dry_run BOOLEAN DEFAULT 0,
+    items_json TEXT,
+    splits_json TEXT,
+    multi_delivery_data TEXT,
+    monarch_notes TEXT,
+    category_id TEXT,
+    category_name TEXT,
+    order_fees_json TEXT,
+    raw_order_json TEXT,
+    match_diagnostics_json TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (run_id) REFERENCES sync_runs(id)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE INDEX IF NOT EXISTS idx_processing_attempts_order_id
+    ON processing_attempts(order_id);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE INDEX IF NOT EXISTS idx_processing_attempts_run_id
+    ON processing_attempts(run_id);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE INDEX IF NOT EXISTS idx_processing_attempts_created_at
+    ON processing_attempts(created_at DESC);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS order_transactions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id INTEGER,
+    order_id TEXT NOT NULL,
+    transaction_id TEXT NOT NULL,
+    role TEXT NOT NULL,
+    amount REAL,
+    category_id TEXT,
+    category_name TEXT,
+    notes TEXT,
+    observed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (run_id) REFERENCES sync_runs(id)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE INDEX IF NOT EXISTS idx_order_transactions_order_id
+    ON order_transactions(order_id);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE INDEX IF NOT EXISTS idx_order_transactions_transaction_id
+    ON order_transactions(transaction_id);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE api_calls ADD COLUMN transaction_id TEXT;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE api_calls ADD COLUMN dry_run BOOLEAN DEFAULT 0;
+-- +goose StatementEnd
+
+-- +goose Down
+-- SQLite cannot drop columns directly. Leave nullable columns/tables in place.

--- a/internal/infrastructure/storage/migrations_test.go
+++ b/internal/infrastructure/storage/migrations_test.go
@@ -14,7 +14,7 @@ import (
 // expectedMigrationCount is the number of migrations we expect to have
 // Update this when adding new migrations
 // Note: goose adds a version 0 entry when initializing, so total count is migrations + 1
-const expectedMigrationCount = 8
+const expectedMigrationCount = 9
 const gooseVersionCount = expectedMigrationCount + 1 // includes goose's version 0 entry
 
 // TestMigrations_FreshDatabase tests running migrations on a fresh database
@@ -92,6 +92,21 @@ func TestMigrations_Schema(t *testing.T) {
 	// Test goose_db_version table exists (goose's migration tracking)
 	err = store.db.QueryRow("SELECT COUNT(*) FROM goose_db_version").Scan(new(int))
 	assert.NoError(t, err, "goose_db_version table should exist")
+
+	// Test processing_attempts table exists (append-only audit trail)
+	err = store.db.QueryRow("SELECT COUNT(*) FROM processing_attempts").Scan(new(int))
+	assert.NoError(t, err, "processing_attempts table should exist")
+
+	// Test order_transactions table exists (one order can touch multiple Monarch transactions)
+	err = store.db.QueryRow("SELECT COUNT(*) FROM order_transactions").Scan(new(int))
+	assert.NoError(t, err, "order_transactions table should exist")
+
+	// Test diagnostic columns exist
+	err = store.db.QueryRow("SELECT match_diagnostics_json FROM processing_records LIMIT 0").Scan()
+	assert.True(t, err == nil || err == sql.ErrNoRows, "processing_records.match_diagnostics_json should exist")
+
+	err = store.db.QueryRow("SELECT transaction_id, dry_run FROM api_calls LIMIT 0").Scan()
+	assert.True(t, err == nil || err == sql.ErrNoRows, "api_calls mutation diagnostic columns should exist")
 }
 
 // TestMigrations_ForeignKeyConstraints tests that foreign keys are enforced

--- a/internal/infrastructure/storage/mock.go
+++ b/internal/infrastructure/storage/mock.go
@@ -4,6 +4,8 @@ package storage
 // It stores all data in maps and slices, making tests fast and isolated.
 type MockRepository struct {
 	records       map[string]*ProcessingRecord
+	attempts      map[string][]ProcessingAttempt
+	orderTxns     map[string][]OrderTransaction
 	syncRuns      map[int64]*mockSyncRun
 	apiCalls      []APICall
 	ledgers       map[string][]*OrderLedger // Keyed by order_id
@@ -47,6 +49,8 @@ type mockSyncRun struct {
 func NewMockRepository() *MockRepository {
 	return &MockRepository{
 		records:       make(map[string]*ProcessingRecord),
+		attempts:      make(map[string][]ProcessingAttempt),
+		orderTxns:     make(map[string][]OrderTransaction),
 		syncRuns:      make(map[int64]*mockSyncRun),
 		apiCalls:      make([]APICall, 0),
 		ledgers:       make(map[string][]*OrderLedger),
@@ -74,8 +78,38 @@ func (m *MockRepository) SaveRecord(record *ProcessingRecord) error {
 	}
 	// Deep copy to avoid test mutations
 	copied := *record
+	m.attempts[record.OrderID] = append(m.attempts[record.OrderID], ProcessingAttempt{ProcessingRecord: copied})
+	if existing, ok := m.records[record.OrderID]; ok && existing.Status == "success" && !existing.DryRun && record.Status != "success" {
+		return nil
+	}
 	m.records[record.OrderID] = &copied
 	return nil
+}
+
+// GetAttemptsByOrderID retrieves append-only attempts for an order.
+func (m *MockRepository) GetAttemptsByOrderID(orderID string) ([]ProcessingAttempt, error) {
+	attempts := m.attempts[orderID]
+	result := make([]ProcessingAttempt, len(attempts))
+	copy(result, attempts)
+	return result, nil
+}
+
+// SaveOrderTransaction records a Monarch transaction association for an order.
+func (m *MockRepository) SaveOrderTransaction(txn *OrderTransaction) error {
+	if txn == nil {
+		return nil
+	}
+	copied := *txn
+	m.orderTxns[txn.OrderID] = append(m.orderTxns[txn.OrderID], copied)
+	return nil
+}
+
+// GetOrderTransactions retrieves Monarch transaction associations for an order.
+func (m *MockRepository) GetOrderTransactions(orderID string) ([]OrderTransaction, error) {
+	txns := m.orderTxns[orderID]
+	result := make([]OrderTransaction, len(txns))
+	copy(result, txns)
+	return result, nil
 }
 
 // GetRecord retrieves a record from the in-memory map
@@ -376,6 +410,9 @@ func (m *MockRepository) GetSyncRun(runID int64) (*SyncRun, error) {
 // AddRecord adds a record directly (for test setup)
 func (m *MockRepository) AddRecord(record *ProcessingRecord) {
 	m.records[record.OrderID] = record
+	if record != nil {
+		m.attempts[record.OrderID] = append(m.attempts[record.OrderID], ProcessingAttempt{ProcessingRecord: *record})
+	}
 }
 
 // GetAllRecords returns all stored records (for assertions)
@@ -395,6 +432,8 @@ func (m *MockRepository) GetMockSyncRun(id int64) *mockSyncRun {
 // Reset clears all data and flags (for reuse between tests)
 func (m *MockRepository) Reset() {
 	m.records = make(map[string]*ProcessingRecord)
+	m.attempts = make(map[string][]ProcessingAttempt)
+	m.orderTxns = make(map[string][]OrderTransaction)
 	m.syncRuns = make(map[int64]*mockSyncRun)
 	m.apiCalls = make([]APICall, 0)
 	m.ledgers = make(map[string][]*OrderLedger)

--- a/internal/infrastructure/storage/mock.go
+++ b/internal/infrastructure/storage/mock.go
@@ -409,8 +409,8 @@ func (m *MockRepository) GetSyncRun(runID int64) (*SyncRun, error) {
 
 // AddRecord adds a record directly (for test setup)
 func (m *MockRepository) AddRecord(record *ProcessingRecord) {
-	m.records[record.OrderID] = record
 	if record != nil {
+		m.records[record.OrderID] = record
 		m.attempts[record.OrderID] = append(m.attempts[record.OrderID], ProcessingAttempt{ProcessingRecord: *record})
 	}
 }

--- a/internal/infrastructure/storage/models.go
+++ b/internal/infrastructure/storage/models.go
@@ -8,6 +8,7 @@ import (
 // ProcessingRecord includes detailed split information
 type ProcessingRecord struct {
 	ID                int64     `json:"id"`
+	RunID             int64     `json:"run_id,omitempty"`
 	OrderID           string    `json:"order_id"`
 	Provider          string    `json:"provider"`
 	TransactionID     string    `json:"transaction_id"`
@@ -40,6 +41,29 @@ type ProcessingRecord struct {
 	CategoryName  string `json:"category_name,omitempty"`   // Human-readable category name
 	OrderFeesJSON string `json:"order_fees_json,omitempty"` // Raw fees breakdown from provider
 	RawOrderJSON  string `json:"raw_order_json,omitempty"`  // Complete raw order data from provider
+
+	// MatchDiagnosticsJSON captures why matching did or did not happen.
+	MatchDiagnosticsJSON string `json:"match_diagnostics_json,omitempty"`
+}
+
+// ProcessingAttempt is an append-only snapshot of each attempt to process an order.
+type ProcessingAttempt struct {
+	ProcessingRecord
+	CreatedAt string `json:"created_at,omitempty"`
+}
+
+// OrderTransaction records every Monarch transaction observed or touched for an order.
+type OrderTransaction struct {
+	ID            int64   `json:"id"`
+	RunID         int64   `json:"run_id,omitempty"`
+	OrderID       string  `json:"order_id"`
+	TransactionID string  `json:"transaction_id"`
+	Role          string  `json:"role"`
+	Amount        float64 `json:"amount"`
+	CategoryID    string  `json:"category_id,omitempty"`
+	CategoryName  string  `json:"category_name,omitempty"`
+	Notes         string  `json:"notes,omitempty"`
+	ObservedAt    string  `json:"observed_at,omitempty"`
 }
 
 // OrderItem represents an item in the order
@@ -120,13 +144,15 @@ type ProviderStats struct {
 
 // APICall represents a logged API call
 type APICall struct {
-	RunID        int64
-	OrderID      string
-	Method       string
-	RequestJSON  string
-	ResponseJSON string
-	Error        string
-	DurationMs   int64
+	RunID         int64
+	OrderID       string
+	TransactionID string
+	Method        string
+	RequestJSON   string
+	ResponseJSON  string
+	Error         string
+	DurationMs    int64
+	DryRun        bool
 }
 
 // LedgerState represents the current state of an order's ledger
@@ -168,9 +194,9 @@ type LedgerCharge struct {
 	SyncRunID            int64     `json:"sync_run_id,omitempty"`
 	ChargeSequence       int       `json:"charge_sequence"` // Order within ledger
 	ChargeAmount         float64   `json:"charge_amount"`
-	ChargeType           string    `json:"charge_type"`            // "payment", "refund"
-	PaymentMethod        string    `json:"payment_method"`         // "CREDITCARD", "GIFTCARD"
-	CardType             string    `json:"card_type,omitempty"`    // "VISA", "AMEX"
+	ChargeType           string    `json:"charge_type"`         // "payment", "refund"
+	PaymentMethod        string    `json:"payment_method"`      // "CREDITCARD", "GIFTCARD"
+	CardType             string    `json:"card_type,omitempty"` // "VISA", "AMEX"
 	CardLastFour         string    `json:"card_last_four,omitempty"`
 	ChargedAt            time.Time `json:"charged_at,omitempty"` // When the charge occurred
 	MonarchTransactionID string    `json:"monarch_transaction_id,omitempty"`

--- a/internal/infrastructure/storage/sqlite.go
+++ b/internal/infrastructure/storage/sqlite.go
@@ -196,20 +196,99 @@ func (s *Storage) SaveRecord(record *ProcessingRecord) error {
 	itemsJSON, _ := json.Marshal(record.Items)
 	splitsJSON, _ := json.Marshal(record.Splits)
 
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	attemptQuery := `
+	INSERT INTO processing_attempts
+	(run_id, order_id, provider, transaction_id, order_date, processed_at,
+	 order_total, order_subtotal, order_tax, order_tip, transaction_amount,
+	 split_count, status, error_message, item_count, match_confidence,
+	 dry_run, items_json, splits_json, multi_delivery_data,
+	 monarch_notes, category_id, category_name, order_fees_json, raw_order_json,
+	 match_diagnostics_json)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`
+
+	if _, err := tx.Exec(attemptQuery,
+		nullInt64(record.RunID),
+		record.OrderID,
+		record.Provider,
+		nullString(record.TransactionID),
+		record.OrderDate,
+		record.ProcessedAt,
+		record.OrderTotal,
+		record.OrderSubtotal,
+		record.OrderTax,
+		record.OrderTip,
+		record.TransactionAmount,
+		record.SplitCount,
+		record.Status,
+		nullString(record.ErrorMessage),
+		record.ItemCount,
+		record.MatchConfidence,
+		record.DryRun,
+		string(itemsJSON),
+		string(splitsJSON),
+		nullString(record.MultiDeliveryData),
+		nullString(record.MonarchNotes),
+		nullString(record.CategoryID),
+		nullString(record.CategoryName),
+		nullString(record.OrderFeesJSON),
+		nullString(record.RawOrderJSON),
+		nullString(record.MatchDiagnosticsJSON),
+	); err != nil {
+		return err
+	}
+
 	query := `
-	INSERT OR REPLACE INTO processing_records
+	INSERT INTO processing_records
 	(order_id, provider, transaction_id, order_date, processed_at,
 	 order_total, order_subtotal, order_tax, order_tip, transaction_amount,
 	 split_count, status, error_message, item_count, match_confidence,
 	 dry_run, items_json, splits_json, multi_delivery_data,
-	 monarch_notes, category_id, category_name, order_fees_json, raw_order_json)
-	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	 monarch_notes, category_id, category_name, order_fees_json, raw_order_json,
+	 match_diagnostics_json)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	ON CONFLICT(order_id) DO UPDATE SET
+	 provider = excluded.provider,
+	 transaction_id = excluded.transaction_id,
+	 order_date = excluded.order_date,
+	 processed_at = excluded.processed_at,
+	 order_total = excluded.order_total,
+	 order_subtotal = excluded.order_subtotal,
+	 order_tax = excluded.order_tax,
+	 order_tip = excluded.order_tip,
+	 transaction_amount = excluded.transaction_amount,
+	 split_count = excluded.split_count,
+	 status = excluded.status,
+	 error_message = excluded.error_message,
+	 item_count = excluded.item_count,
+	 match_confidence = excluded.match_confidence,
+	 dry_run = excluded.dry_run,
+	 items_json = excluded.items_json,
+	 splits_json = excluded.splits_json,
+	 multi_delivery_data = excluded.multi_delivery_data,
+	 monarch_notes = excluded.monarch_notes,
+	 category_id = excluded.category_id,
+	 category_name = excluded.category_name,
+	 order_fees_json = excluded.order_fees_json,
+	 raw_order_json = excluded.raw_order_json,
+	 match_diagnostics_json = excluded.match_diagnostics_json
+	WHERE NOT (
+		processing_records.status = 'success'
+		AND processing_records.dry_run = 0
+		AND excluded.status != 'success'
+	)
 	`
 
-	_, err := s.db.Exec(query,
+	if _, err := tx.Exec(query,
 		record.OrderID,
 		record.Provider,
-		record.TransactionID,
+		nullString(record.TransactionID),
 		record.OrderDate,
 		record.ProcessedAt,
 		record.OrderTotal,
@@ -231,9 +310,12 @@ func (s *Storage) SaveRecord(record *ProcessingRecord) error {
 		nullString(record.CategoryName),
 		nullString(record.OrderFeesJSON),
 		nullString(record.RawOrderJSON),
-	)
+		nullString(record.MatchDiagnosticsJSON),
+	); err != nil {
+		return err
+	}
 
-	return err
+	return tx.Commit()
 }
 
 // GetRecord retrieves an enhanced record by order ID
@@ -243,7 +325,8 @@ func (s *Storage) GetRecord(orderID string) (*ProcessingRecord, error) {
 	       order_total, order_subtotal, order_tax, order_tip, transaction_amount,
 	       split_count, status, error_message, item_count, match_confidence,
 	       dry_run, items_json, splits_json, multi_delivery_data,
-	       monarch_notes, category_id, category_name, order_fees_json, raw_order_json
+	       monarch_notes, category_id, category_name, order_fees_json, raw_order_json,
+	       match_diagnostics_json
 	FROM processing_records WHERE order_id = ?
 	`
 
@@ -259,6 +342,7 @@ func (s *Storage) GetRecord(orderID string) (*ProcessingRecord, error) {
 		categoryName      sql.NullString
 		orderFeesJSON     sql.NullString
 		rawOrderJSON      sql.NullString
+		matchDiagnostics  sql.NullString
 	)
 	err := s.db.QueryRow(query, orderID).Scan(
 		&record.ID,
@@ -286,6 +370,7 @@ func (s *Storage) GetRecord(orderID string) (*ProcessingRecord, error) {
 		&categoryName,
 		&orderFeesJSON,
 		&rawOrderJSON,
+		&matchDiagnostics,
 	)
 
 	if err != nil {
@@ -326,6 +411,9 @@ func (s *Storage) GetRecord(orderID string) (*ProcessingRecord, error) {
 	if rawOrderJSON.Valid {
 		record.RawOrderJSON = rawOrderJSON.String
 	}
+	if matchDiagnostics.Valid {
+		record.MatchDiagnosticsJSON = matchDiagnostics.String
+	}
 
 	// Unmarshal JSON fields (errors ignored as these are optional enrichment fields)
 	if record.ItemsJSON != "" {
@@ -336,6 +424,188 @@ func (s *Storage) GetRecord(orderID string) (*ProcessingRecord, error) {
 	}
 
 	return record, nil
+}
+
+// GetAttemptsByOrderID retrieves append-only attempts for an order.
+func (s *Storage) GetAttemptsByOrderID(orderID string) ([]ProcessingAttempt, error) {
+	query := `
+	SELECT id, COALESCE(run_id, 0), order_id, provider, transaction_id, order_date, processed_at,
+	       order_total, order_subtotal, order_tax, order_tip, transaction_amount,
+	       split_count, status, error_message, item_count, match_confidence,
+	       dry_run, items_json, splits_json, multi_delivery_data,
+	       monarch_notes, category_id, category_name, order_fees_json, raw_order_json,
+	       match_diagnostics_json, created_at
+	FROM processing_attempts
+	WHERE order_id = ?
+	ORDER BY id ASC
+	`
+
+	rows, err := s.db.Query(query, orderID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var attempts []ProcessingAttempt
+	for rows.Next() {
+		var attempt ProcessingAttempt
+		var (
+			transactionID     sql.NullString
+			errorMessage      sql.NullString
+			itemsJSON         sql.NullString
+			splitsJSON        sql.NullString
+			multiDeliveryData sql.NullString
+			monarchNotes      sql.NullString
+			categoryID        sql.NullString
+			categoryName      sql.NullString
+			orderFeesJSON     sql.NullString
+			rawOrderJSON      sql.NullString
+			matchDiagnostics  sql.NullString
+		)
+
+		if err := rows.Scan(
+			&attempt.ID,
+			&attempt.RunID,
+			&attempt.OrderID,
+			&attempt.Provider,
+			&transactionID,
+			&attempt.OrderDate,
+			&attempt.ProcessedAt,
+			&attempt.OrderTotal,
+			&attempt.OrderSubtotal,
+			&attempt.OrderTax,
+			&attempt.OrderTip,
+			&attempt.TransactionAmount,
+			&attempt.SplitCount,
+			&attempt.Status,
+			&errorMessage,
+			&attempt.ItemCount,
+			&attempt.MatchConfidence,
+			&attempt.DryRun,
+			&itemsJSON,
+			&splitsJSON,
+			&multiDeliveryData,
+			&monarchNotes,
+			&categoryID,
+			&categoryName,
+			&orderFeesJSON,
+			&rawOrderJSON,
+			&matchDiagnostics,
+			&attempt.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+
+		if transactionID.Valid {
+			attempt.TransactionID = transactionID.String
+		}
+		if errorMessage.Valid {
+			attempt.ErrorMessage = errorMessage.String
+		}
+		if itemsJSON.Valid {
+			attempt.ItemsJSON = itemsJSON.String
+			_ = json.Unmarshal([]byte(attempt.ItemsJSON), &attempt.Items)
+		}
+		if splitsJSON.Valid {
+			attempt.SplitsJSON = splitsJSON.String
+			_ = json.Unmarshal([]byte(attempt.SplitsJSON), &attempt.Splits)
+		}
+		if multiDeliveryData.Valid {
+			attempt.MultiDeliveryData = multiDeliveryData.String
+		}
+		if monarchNotes.Valid {
+			attempt.MonarchNotes = monarchNotes.String
+		}
+		if categoryID.Valid {
+			attempt.CategoryID = categoryID.String
+		}
+		if categoryName.Valid {
+			attempt.CategoryName = categoryName.String
+		}
+		if orderFeesJSON.Valid {
+			attempt.OrderFeesJSON = orderFeesJSON.String
+		}
+		if rawOrderJSON.Valid {
+			attempt.RawOrderJSON = rawOrderJSON.String
+		}
+		if matchDiagnostics.Valid {
+			attempt.MatchDiagnosticsJSON = matchDiagnostics.String
+		}
+
+		attempts = append(attempts, attempt)
+	}
+
+	return attempts, rows.Err()
+}
+
+// SaveOrderTransaction records a Monarch transaction associated with an order.
+func (s *Storage) SaveOrderTransaction(txn *OrderTransaction) error {
+	if txn == nil {
+		return nil
+	}
+	query := `
+		INSERT INTO order_transactions
+		(run_id, order_id, transaction_id, role, amount, category_id, category_name, notes)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`
+	_, err := s.db.Exec(query,
+		nullInt64(txn.RunID),
+		txn.OrderID,
+		txn.TransactionID,
+		txn.Role,
+		txn.Amount,
+		nullString(txn.CategoryID),
+		nullString(txn.CategoryName),
+		nullString(txn.Notes),
+	)
+	return err
+}
+
+// GetOrderTransactions retrieves Monarch transaction associations for an order.
+func (s *Storage) GetOrderTransactions(orderID string) ([]OrderTransaction, error) {
+	query := `
+		SELECT id, COALESCE(run_id, 0), order_id, transaction_id, role, amount,
+		       category_id, category_name, notes, observed_at
+		FROM order_transactions
+		WHERE order_id = ?
+		ORDER BY id ASC
+	`
+	rows, err := s.db.Query(query, orderID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var txns []OrderTransaction
+	for rows.Next() {
+		var txn OrderTransaction
+		var categoryID, categoryName, notes sql.NullString
+		if err := rows.Scan(
+			&txn.ID,
+			&txn.RunID,
+			&txn.OrderID,
+			&txn.TransactionID,
+			&txn.Role,
+			&txn.Amount,
+			&categoryID,
+			&categoryName,
+			&notes,
+			&txn.ObservedAt,
+		); err != nil {
+			return nil, err
+		}
+		if categoryID.Valid {
+			txn.CategoryID = categoryID.String
+		}
+		if categoryName.Valid {
+			txn.CategoryName = categoryName.String
+		}
+		if notes.Valid {
+			txn.Notes = notes.String
+		}
+		txns = append(txns, txn)
+	}
+	return txns, rows.Err()
 }
 
 // GetStats returns enhanced statistics
@@ -443,8 +713,8 @@ func (s *Storage) CompleteSyncRun(runID int64, ordersFound, processed, skipped, 
 func (s *Storage) LogAPICall(call *APICall) error {
 	query := `
 		INSERT INTO api_calls
-		(run_id, order_id, method, request_json, response_json, error, duration_ms)
-		VALUES (?, ?, ?, ?, ?, ?, ?)
+		(run_id, order_id, method, request_json, response_json, error, duration_ms, transaction_id, dry_run)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 
 	_, err := s.db.Exec(query,
@@ -455,6 +725,8 @@ func (s *Storage) LogAPICall(call *APICall) error {
 		call.ResponseJSON,
 		call.Error,
 		call.DurationMs,
+		nullString(call.TransactionID),
+		call.DryRun,
 	)
 
 	return err
@@ -463,7 +735,8 @@ func (s *Storage) LogAPICall(call *APICall) error {
 // GetAPICallsByOrderID retrieves all API calls for a specific order
 func (s *Storage) GetAPICallsByOrderID(orderID string) ([]APICall, error) {
 	query := `
-		SELECT run_id, order_id, method, request_json, response_json, error, duration_ms, timestamp
+		SELECT run_id, order_id, method, request_json, response_json, error, duration_ms, timestamp,
+		       transaction_id, dry_run
 		FROM api_calls
 		WHERE order_id = ?
 		ORDER BY timestamp ASC
@@ -479,6 +752,7 @@ func (s *Storage) GetAPICallsByOrderID(orderID string) ([]APICall, error) {
 	for rows.Next() {
 		var call APICall
 		var timestamp string
+		var transactionID sql.NullString
 		err := rows.Scan(
 			&call.RunID,
 			&call.OrderID,
@@ -488,9 +762,14 @@ func (s *Storage) GetAPICallsByOrderID(orderID string) ([]APICall, error) {
 			&call.Error,
 			&call.DurationMs,
 			&timestamp,
+			&transactionID,
+			&call.DryRun,
 		)
 		if err != nil {
 			return nil, err
+		}
+		if transactionID.Valid {
+			call.TransactionID = transactionID.String
 		}
 		calls = append(calls, call)
 	}
@@ -501,7 +780,8 @@ func (s *Storage) GetAPICallsByOrderID(orderID string) ([]APICall, error) {
 // GetAPICallsByRunID retrieves all API calls for a specific sync run
 func (s *Storage) GetAPICallsByRunID(runID int64) ([]APICall, error) {
 	query := `
-		SELECT run_id, order_id, method, request_json, response_json, error, duration_ms, timestamp
+		SELECT run_id, order_id, method, request_json, response_json, error, duration_ms, timestamp,
+		       transaction_id, dry_run
 		FROM api_calls
 		WHERE run_id = ?
 		ORDER BY timestamp ASC
@@ -517,6 +797,7 @@ func (s *Storage) GetAPICallsByRunID(runID int64) ([]APICall, error) {
 	for rows.Next() {
 		var call APICall
 		var timestamp string
+		var transactionID sql.NullString
 		err := rows.Scan(
 			&call.RunID,
 			&call.OrderID,
@@ -526,9 +807,14 @@ func (s *Storage) GetAPICallsByRunID(runID int64) ([]APICall, error) {
 			&call.Error,
 			&call.DurationMs,
 			&timestamp,
+			&transactionID,
+			&call.DryRun,
 		)
 		if err != nil {
 			return nil, err
+		}
+		if transactionID.Valid {
+			call.TransactionID = transactionID.String
 		}
 		calls = append(calls, call)
 	}
@@ -598,7 +884,8 @@ func (s *Storage) ListOrders(filters OrderFilters) (*OrderListResult, error) {
 		       order_total, order_subtotal, order_tax, order_tip, transaction_amount,
 		       split_count, status, error_message, item_count, match_confidence,
 		       dry_run, items_json, splits_json, multi_delivery_data,
-		       monarch_notes, category_id, category_name, order_fees_json, raw_order_json
+		       monarch_notes, category_id, category_name, order_fees_json, raw_order_json,
+		       match_diagnostics_json
 		FROM processing_records
 		%s
 		ORDER BY %s %s
@@ -627,6 +914,7 @@ func (s *Storage) ListOrders(filters OrderFilters) (*OrderListResult, error) {
 			categoryName      sql.NullString
 			orderFeesJSON     sql.NullString
 			rawOrderJSON      sql.NullString
+			matchDiagnostics  sql.NullString
 		)
 		err := rows.Scan(
 			&record.ID,
@@ -654,6 +942,7 @@ func (s *Storage) ListOrders(filters OrderFilters) (*OrderListResult, error) {
 			&categoryName,
 			&orderFeesJSON,
 			&rawOrderJSON,
+			&matchDiagnostics,
 		)
 		if err != nil {
 			return nil, err
@@ -689,6 +978,9 @@ func (s *Storage) ListOrders(filters OrderFilters) (*OrderListResult, error) {
 		}
 		if rawOrderJSON.Valid {
 			record.RawOrderJSON = rawOrderJSON.String
+		}
+		if matchDiagnostics.Valid {
+			record.MatchDiagnosticsJSON = matchDiagnostics.String
 		}
 
 		// Unmarshal JSON fields

--- a/internal/infrastructure/storage/storage_test.go
+++ b/internal/infrastructure/storage/storage_test.go
@@ -122,20 +122,20 @@ func TestStorage_SaveAndGetRecord_WithItems(t *testing.T) {
 
 	// Create a record with items
 	record := &ProcessingRecord{
-		OrderID:         "ORDER-123",
-		Provider:        "walmart",
-		TransactionID:   "txn-456",
-		OrderDate:       time.Now().Truncate(time.Second),
-		ProcessedAt:     time.Now().Truncate(time.Second),
-		OrderTotal:      150.00,
-		OrderSubtotal:   140.00,
-		OrderTax:        10.00,
+		OrderID:           "ORDER-123",
+		Provider:          "walmart",
+		TransactionID:     "txn-456",
+		OrderDate:         time.Now().Truncate(time.Second),
+		ProcessedAt:       time.Now().Truncate(time.Second),
+		OrderTotal:        150.00,
+		OrderSubtotal:     140.00,
+		OrderTax:          10.00,
 		TransactionAmount: -150.00,
-		SplitCount:      2,
-		Status:          "success",
-		ItemCount:       3,
-		MatchConfidence: 0.95,
-		DryRun:          false,
+		SplitCount:        2,
+		Status:            "success",
+		ItemCount:         3,
+		MatchConfidence:   0.95,
+		DryRun:            false,
 		Items: []OrderItem{
 			{Name: "Milk", Quantity: 2, UnitPrice: 3.99, TotalPrice: 7.98, Category: "Groceries"},
 			{Name: "Bread", Quantity: 1, UnitPrice: 2.50, TotalPrice: 2.50, Category: "Groceries"},
@@ -269,6 +269,118 @@ func TestStorage_SaveRecord_UpdateExisting(t *testing.T) {
 	assert.Equal(t, "success", retrieved.Status)
 	require.Len(t, retrieved.Items, 1)
 	assert.Equal(t, "Updated Item", retrieved.Items[0].Name)
+}
+
+func TestStorage_SaveRecord_DoesNotDowngradeSuccessWithFailure(t *testing.T) {
+	tmpDB := createTempDB(t)
+	defer os.Remove(tmpDB)
+
+	store, err := NewStorage(tmpDB)
+	require.NoError(t, err)
+	defer store.Close()
+
+	success := &ProcessingRecord{
+		OrderID:           "ORDER-SAFE",
+		Provider:          "costco",
+		TransactionID:     "txn-success",
+		OrderDate:         time.Now().Truncate(time.Second),
+		ProcessedAt:       time.Now().Truncate(time.Second),
+		OrderTotal:        307.79,
+		TransactionAmount: -307.79,
+		SplitCount:        4,
+		Status:            "success",
+		RawOrderJSON:      `{"receipt":"full"}`,
+		Splits: []SplitDetail{
+			{CategoryID: "groceries", Amount: -127.64, Notes: "Groceries:\n- CANTALOUPE $6.99"},
+		},
+	}
+	require.NoError(t, store.SaveRecord(success))
+
+	failedRetry := &ProcessingRecord{
+		OrderID:      "ORDER-SAFE",
+		Provider:     "costco",
+		OrderDate:    success.OrderDate,
+		ProcessedAt:  success.ProcessedAt.Add(time.Minute),
+		OrderTotal:   307.79,
+		Status:       "failed",
+		ErrorMessage: "no matching transaction found",
+		Items:        []OrderItem{{Name: "CANTALOUPE", TotalPrice: 6.99}},
+	}
+	require.NoError(t, store.SaveRecord(failedRetry))
+
+	retrieved, err := store.GetRecord("ORDER-SAFE")
+	require.NoError(t, err)
+	require.NotNil(t, retrieved)
+	assert.Equal(t, "success", retrieved.Status)
+	assert.Equal(t, "txn-success", retrieved.TransactionID)
+	assert.Equal(t, -307.79, retrieved.TransactionAmount)
+	assert.Equal(t, 4, retrieved.SplitCount)
+	assert.Equal(t, `{"receipt":"full"}`, retrieved.RawOrderJSON)
+	require.Len(t, retrieved.Splits, 1)
+}
+
+func TestStorage_SaveRecord_AppendsAttemptHistory(t *testing.T) {
+	tmpDB := createTempDB(t)
+	defer os.Remove(tmpDB)
+
+	store, err := NewStorage(tmpDB)
+	require.NoError(t, err)
+	defer store.Close()
+
+	require.NoError(t, store.SaveRecord(&ProcessingRecord{
+		OrderID:     "ORDER-HISTORY",
+		Provider:    "costco",
+		ProcessedAt: time.Now().Add(-time.Minute),
+		Status:      "success",
+		Splits:      []SplitDetail{{CategoryID: "groceries", Amount: -10.00}},
+	}))
+	require.NoError(t, store.SaveRecord(&ProcessingRecord{
+		OrderID:              "ORDER-HISTORY",
+		Provider:             "costco",
+		ProcessedAt:          time.Now(),
+		Status:               "failed",
+		ErrorMessage:         "no matching transaction found",
+		MatchDiagnosticsJSON: `{"closest":[{"id":"txn-1"}]}`,
+	}))
+
+	attempts, err := store.GetAttemptsByOrderID("ORDER-HISTORY")
+	require.NoError(t, err)
+	require.Len(t, attempts, 2)
+	assert.Equal(t, "success", attempts[0].Status)
+	assert.Equal(t, "failed", attempts[1].Status)
+	assert.Equal(t, `{"closest":[{"id":"txn-1"}]}`, attempts[1].MatchDiagnosticsJSON)
+}
+
+func TestStorage_OrderTransactions_MultipleRowsPerOrder(t *testing.T) {
+	tmpDB := createTempDB(t)
+	defer os.Remove(tmpDB)
+
+	store, err := NewStorage(tmpDB)
+	require.NoError(t, err)
+	defer store.Close()
+
+	require.NoError(t, store.SaveOrderTransaction(&OrderTransaction{
+		OrderID:       "ORDER-TXNS",
+		TransactionID: "txn-parent",
+		Role:          "matched",
+		Amount:        -307.79,
+	}))
+	require.NoError(t, store.SaveOrderTransaction(&OrderTransaction{
+		OrderID:       "ORDER-TXNS",
+		TransactionID: "txn-child",
+		Role:          "reconciled",
+		Amount:        -127.64,
+		Notes:         "Groceries:\n- CANTALOUPE $6.99",
+	}))
+
+	txns, err := store.GetOrderTransactions("ORDER-TXNS")
+	require.NoError(t, err)
+	require.Len(t, txns, 2)
+	assert.Equal(t, "txn-parent", txns[0].TransactionID)
+	assert.Equal(t, "matched", txns[0].Role)
+	assert.Equal(t, "txn-child", txns[1].TransactionID)
+	assert.Equal(t, "reconciled", txns[1].Role)
+	assert.Contains(t, txns[1].Notes, "CANTALOUPE")
 }
 
 func TestStorage_IsProcessed(t *testing.T) {


### PR DESCRIPTION
## Summary
- add append-only processing attempts and order transaction audit tables
- prevent failed/pending retries from overwriting successful processing summaries
- log normal Monarch update/split mutations with order and transaction metadata
- reconcile already-split Costco/simple transactions before recording no-match failures

## Verification
- go test ./...
- go build -o itemize ./cmd/itemize/

## Notes
This addresses the Costco case where Monarch showed split transactions for an order while SQLite only retained a later failed no-match record.