### PR TITLE
feat: add guided Amazon account setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,32 +135,30 @@ Requires cookies in `~/.walmart-api/cookies.json`. See [walmart-client-go](https
 Uses credentials saved by [costco-go](https://github.com/eshaffer321/costco-go).
 
 ### Amazon
-Uses [amazon-go](https://github.com/eshaffer321/amazon-go) as a library. Authenticate once by
-saving Amazon cookies from a browser profile that is already logged into Amazon:
+Set up an account with Itemize's guided login command:
 
-The browser-profile import uses Playwright to open Chromium. If Playwright is not already
-installed globally or in this repo, install it once:
+```bash
+./itemize amazon setup -account erick
+```
+
+Itemize creates a persistent browser profile under `~/.itemize/amazon/`, opens Chromium, and waits
+for you to sign into Amazon. After setup, verify the account with a small dry run:
+
+```bash
+./itemize amazon -account erick -dry-run -days 14 -max 1
+```
+
+Itemize uses [amazon-go](https://github.com/eshaffer321/amazon-go) as a library. The login flow uses
+Playwright to open Chromium. If Playwright is not already installed globally or in this repo,
+install it once:
 
 ```bash
 npm install playwright
 ```
 
-If Playwright lives somewhere else, pass `-playwright-root <dir>` where `<dir>` contains
-`node_modules/playwright`.
-
-```bash
-./itemize amazon \
-  -import-browser-profile "$HOME/.itemize/amazon/amazon-erick" \
-  -account erick
-```
-
-If you set `AMAZON_ACCOUNT_NAME`, save cookies for the matching amazon-go account:
-
-```bash
-./itemize amazon \
-  -import-browser-profile "$HOME/.itemize/amazon/$AMAZON_ACCOUNT_NAME" \
-  -account "$AMAZON_ACCOUNT_NAME"
-```
+If Playwright lives elsewhere, add `-playwright-root <dir>` to `amazon setup`, where `<dir>`
+contains `node_modules/playwright`. The lower-level `-import-browser-profile` flag remains
+available for importing a specific existing Chromium/Playwright profile.
 
 #### Multiple Amazon accounts
 

--- a/cmd/itemize/main.go
+++ b/cmd/itemize/main.go
@@ -51,15 +51,18 @@ func main() {
 
 	// Provider sync commands
 	providerName := command
+	amazonSetup := providerName == "amazon" && len(os.Args) > 2 && os.Args[2] == "setup"
 	// Shift args for flag parsing
-	if providerName == "amazon" && len(os.Args) > 2 && !strings.HasPrefix(os.Args[2], "-") {
+	if amazonSetup {
+		os.Args = append([]string{os.Args[0]}, os.Args[3:]...)
+	} else if providerName == "amazon" && len(os.Args) > 2 && !strings.HasPrefix(os.Args[2], "-") {
 		os.Args = append([]string{os.Args[0], "-account", os.Args[2]}, os.Args[3:]...)
 	} else {
 		os.Args = append([]string{os.Args[0]}, os.Args[2:]...)
 	}
 
 	// Parse common flags
-	flags := cli.ParseSyncFlags()
+	flags := cli.ParseSyncFlags(providerName)
 
 	// Load config
 	cfg := config.LoadOrEnv()
@@ -74,7 +77,11 @@ func main() {
 
 	amazonAccount := ""
 	if providerName == "amazon" {
-		amazonAccount, err = cli.ResolveAmazonAccount(cfg, flags.Account, flags.ExtraArgs)
+		if amazonSetup {
+			amazonAccount, err = cli.ResolveAmazonSetupAccount(flags.Account, flags.ExtraArgs)
+		} else {
+			amazonAccount, err = cli.ResolveAmazonAccount(cfg, flags.Account, flags.ExtraArgs)
+		}
 		if err != nil {
 			log.Fatalf("Invalid Amazon account arguments: %v", err)
 		}
@@ -94,7 +101,7 @@ func main() {
 		}
 		if len(accounts) == 0 {
 			fmt.Println("No saved Amazon accounts found.")
-			fmt.Println("Run 'itemize amazon -import-browser-profile <profile-dir> -account <name>' to create one.")
+			fmt.Println("Run 'itemize amazon setup -account <name>' to create one.")
 			return
 		}
 		fmt.Println("Saved Amazon accounts:")
@@ -103,6 +110,22 @@ func main() {
 		}
 		fmt.Println()
 		fmt.Println("Use with: itemize amazon -account <name>")
+		return
+	}
+
+	if amazonSetup {
+		if flags.ImportBrowserProfile != "" {
+			log.Fatalf("amazon setup creates its own browser profile; omit -import-browser-profile")
+		}
+		if err := cli.RunAmazonSetup(cfg, cli.AmazonImportOptions{
+			Account:        amazonAccount,
+			CookieFile:     cfg.Providers.Amazon.CookieFile,
+			PlaywrightRoot: flags.PlaywrightRoot,
+			Headless:       flags.Headless,
+			SkipAuthCheck:  flags.SkipAuthCheck,
+		}); err != nil {
+			log.Fatalf("Amazon setup failed: %v", err)
+		}
 		return
 	}
 
@@ -205,6 +228,8 @@ func printUsage() {
 	fmt.Println("Commands:")
 	fmt.Println("  serve       Start the API server")
 	fmt.Println("  amazon      Sync Amazon orders")
+	fmt.Println("  amazon setup -account <name>")
+	fmt.Println("              Create an Amazon account and open Chromium for sign-in")
 	fmt.Println("  costco      Sync Costco orders")
 	fmt.Println("  walmart     Sync Walmart orders")
 	fmt.Println("  version     Print version, commit, and build date (also: -version, --version)")
@@ -224,6 +249,8 @@ func printUsage() {
 	fmt.Println("  -cookie-file string")
 	fmt.Println("                  Explicit Amazon cookie file (amazon only)")
 	fmt.Println("  -list-accounts   List saved Amazon cookie accounts and exit (amazon only)")
+	fmt.Println()
+	fmt.Println("Advanced Amazon Authentication:")
 	fmt.Println("  -import-browser-profile string")
 	fmt.Println("                  Import Amazon cookies from a Chromium/Playwright profile and exit (amazon only)")
 	fmt.Println("  -playwright-root string")

--- a/internal/adapters/providers/amazon/provider.go
+++ b/internal/adapters/providers/amazon/provider.go
@@ -240,9 +240,9 @@ func (p *Provider) loginCommand() string {
 		accountArg = " -account " + p.profile
 	}
 	if p.cookieFile != "" {
-		return fmt.Sprintf("run 'itemize amazon -import-browser-profile <profile-dir> -cookie-file %q' to authenticate", p.cookieFile)
+		return fmt.Sprintf("run 'itemize amazon setup -account <name> -cookie-file %q' to authenticate", p.cookieFile)
 	}
-	return fmt.Sprintf("run 'itemize amazon -import-browser-profile <profile-dir>%s' to authenticate", accountArg)
+	return fmt.Sprintf("run 'itemize amazon setup%s' to authenticate", accountArg)
 }
 
 func (p *Provider) authCheckError(err error) error {

--- a/internal/adapters/providers/amazon/provider_test.go
+++ b/internal/adapters/providers/amazon/provider_test.go
@@ -158,7 +158,7 @@ func TestProvider_FetchOrdersReturnsHealthCheckError(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, orders)
 	assert.Contains(t, err.Error(), "amazon auth check failed")
-	assert.Contains(t, err.Error(), "itemize amazon -import-browser-profile <profile-dir> -account wife")
+	assert.Contains(t, err.Error(), "itemize amazon setup -account wife")
 	assert.True(t, client.healthChecked)
 }
 
@@ -227,7 +227,7 @@ func TestProvider_HealthCheckWrapsAuthErrorWithLoginCommand(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "amazon auth check failed")
-	assert.Contains(t, err.Error(), "itemize amazon -import-browser-profile <profile-dir> -account wife")
+	assert.Contains(t, err.Error(), "itemize amazon setup -account wife")
 }
 
 func TestConvertGoTransactionMapsRefundAndPendingStatuses(t *testing.T) {
@@ -244,7 +244,7 @@ func TestLoginCommandUsesExplicitCookieFile(t *testing.T) {
 	provider := NewProvider(nil, &ProviderConfig{CookieFile: "/tmp/amazon-cookies.json"})
 
 	assert.Contains(t, provider.loginCommand(), `-cookie-file "/tmp/amazon-cookies.json"`)
-	assert.Contains(t, provider.loginCommand(), "itemize amazon -import-browser-profile <profile-dir>")
+	assert.Contains(t, provider.loginCommand(), "itemize amazon setup")
 }
 
 type fakeAmazonClient struct {

--- a/internal/cli/amazon_auth.go
+++ b/internal/cli/amazon_auth.go
@@ -49,6 +49,8 @@ func PrepareAmazonSetup(account string) (string, error) {
 	if err := os.MkdirAll(profileDir, 0700); err != nil {
 		return "", fmt.Errorf("failed to create Amazon browser profile %q: %w", profileDir, err)
 	}
+	// #nosec G302 -- profileDir is a directory containing browser state; owner-only
+	// traversal is intentional and more restrictive than the directory default.
 	if err := os.Chmod(profileDir, 0700); err != nil {
 		return "", fmt.Errorf("failed to secure Amazon browser profile %q: %w", profileDir, err)
 	}

--- a/internal/cli/amazon_auth.go
+++ b/internal/cli/amazon_auth.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -28,6 +29,51 @@ type AmazonImportOptions struct {
 	Headless       bool
 	SkipAuthCheck  bool
 	Out            io.Writer
+}
+
+// PrepareAmazonSetup creates the persistent browser profile used for an Amazon
+// account. Keeping this convention inside itemize lets first-time users avoid
+// choosing or managing Chromium profile paths themselves.
+func PrepareAmazonSetup(account string) (string, error) {
+	if account == "" {
+		return "", fmt.Errorf("amazon setup requires -account <name>")
+	}
+	if !regexp.MustCompile(`^[A-Za-z0-9_-]+$`).MatchString(account) {
+		return "", fmt.Errorf("invalid Amazon account name %q: use only letters, numbers, dashes, and underscores", account)
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	profileDir := filepath.Join(homeDir, ".itemize", "amazon", account)
+	if err := os.MkdirAll(profileDir, 0700); err != nil {
+		return "", fmt.Errorf("failed to create Amazon browser profile %q: %w", profileDir, err)
+	}
+	if err := os.Chmod(profileDir, 0700); err != nil {
+		return "", fmt.Errorf("failed to secure Amazon browser profile %q: %w", profileDir, err)
+	}
+	return profileDir, nil
+}
+
+// RunAmazonSetup provides the guided first-time authentication path while the
+// lower-level browser profile import remains available for advanced use.
+func RunAmazonSetup(cfg *config.Config, opts AmazonImportOptions) error {
+	profileDir, err := PrepareAmazonSetup(opts.Account)
+	if err != nil {
+		return err
+	}
+	opts.ProfileDir = profileDir
+	if opts.Out == nil {
+		opts.Out = os.Stdout
+	}
+	if _, err := fmt.Fprintf(opts.Out, "Amazon setup for account %q.\nOpening Chromium; sign in to Amazon when prompted. Itemize will continue after Your Orders loads.\nBrowser profile: %s\n\n", opts.Account, profileDir); err != nil {
+		return fmt.Errorf("failed to write setup instructions: %w", err)
+	}
+	if err := RunAmazonBrowserProfileImport(cfg, opts); err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(opts.Out, "\nSetup complete. Test safely with:\n  itemize amazon -account %s -dry-run -days 14 -max 1\n", opts.Account)
+	return err
 }
 
 // RunAmazonBrowserProfileImport imports Amazon cookies into itemize's Amazon cookie store.
@@ -404,7 +450,7 @@ func resolvePlaywrightRoot(explicit string) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("install Playwright with `npm install playwright` or pass -playwright-root pointing at a directory containing node_modules/playwright")
+	return "", fmt.Errorf("playwright is required for Amazon login; install it with `npm install playwright`, then rerun setup (or pass -playwright-root pointing at a directory containing node_modules/playwright)")
 }
 
 func npmRoot(args ...string) (string, error) {

--- a/internal/cli/amazon_setup_test.go
+++ b/internal/cli/amazon_setup_test.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareAmazonSetup_CreatesDefaultProfileDirectory(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	profileDir, err := PrepareAmazonSetup("wife")
+
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".itemize", "amazon", "wife"), profileDir)
+	info, err := os.Stat(profileDir)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+	assert.Equal(t, os.FileMode(0700), info.Mode().Perm())
+}
+
+func TestPrepareAmazonSetup_RequiresAccount(t *testing.T) {
+	_, err := PrepareAmazonSetup("")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "-account")
+}
+
+func TestPrepareAmazonSetup_RejectsUnsafeAccountName(t *testing.T) {
+	_, err := PrepareAmazonSetup("../wife")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "letters, numbers, dashes, and underscores")
+}
+
+func TestPrintAmazonUsage_PutsSetupBeforeSyncAndAdvancedFlags(t *testing.T) {
+	var out bytes.Buffer
+
+	PrintAmazonUsage(&out)
+
+	help := out.String()
+	setup := strings.Index(help, "First-time setup")
+	sync := strings.Index(help, "Sync options")
+	advanced := strings.Index(help, "Advanced authentication")
+	require.NotEqual(t, -1, setup)
+	require.NotEqual(t, -1, sync)
+	require.NotEqual(t, -1, advanced)
+	assert.Less(t, setup, sync)
+	assert.Less(t, sync, advanced)
+	assert.Contains(t, help, "itemize amazon setup -account <name>")
+	assert.Contains(t, help, "Creates a browser profile and opens Chromium")
+}

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"flag"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/eshaffer321/itemize/internal/application/sync"
@@ -27,7 +28,7 @@ type SyncFlags struct {
 }
 
 // ParseSyncFlags parses common sync flags from command line
-func ParseSyncFlags() SyncFlags {
+func ParseSyncFlags(providerName string) SyncFlags {
 	var flags SyncFlags
 	flag.BoolVar(&flags.DryRun, "dry-run", false, "Run without making changes")
 	flag.IntVar(&flags.LookbackDays, "days", 14, "Number of days to look back")
@@ -44,6 +45,10 @@ func ParseSyncFlags() SyncFlags {
 	flag.BoolVar(&flags.SkipAuthCheck, "skip-auth-check", false, "Skip Amazon auth validation after importing cookies")
 
 	flag.Usage = func() {
+		if providerName == "amazon" {
+			PrintAmazonUsage(os.Stderr)
+			return
+		}
 		fmt.Fprintln(os.Stderr, "Usage: itemize <command> [flags]")
 		fmt.Fprintln(os.Stderr)
 		fmt.Fprintln(os.Stderr, "Sync Flags:")
@@ -65,6 +70,42 @@ func ParseSyncFlags() SyncFlags {
 	flag.Parse()
 	flags.ExtraArgs = flag.Args()
 	return flags
+}
+
+// PrintAmazonUsage keeps the guided setup path prominent and moves the
+// implementation-level authentication controls below normal sync options.
+func PrintAmazonUsage(w io.Writer) {
+	_, _ = fmt.Fprint(w, `Usage:
+  itemize amazon setup -account <name>
+  itemize amazon -account <name> [sync options]
+
+First-time setup:
+  setup                    Creates a browser profile and opens Chromium for Amazon sign-in
+  -account string          Name used to save and select this Amazon account
+
+Account management:
+  -list-accounts           List saved Amazon accounts
+
+Sync options:
+  -dry-run                 Preview without making Monarch changes
+  -days int                Number of days to look back (default 14)
+  -max int                 Maximum orders to process (0 = all)
+  -order-id string         Process only one order
+  -force                   Reprocess previously processed orders
+  -verbose                 Show debug diagnostics
+
+Advanced authentication:
+  -import-browser-profile string
+                            Import cookies from a specific Chromium/Playwright profile
+  -playwright-root string   Directory containing node_modules/playwright
+  -cookie-file string       Explicit Amazon cookie file
+  -headless                 Run profile import headlessly
+  -skip-auth-check          Skip validation after importing cookies
+
+Examples:
+  itemize amazon setup -account wife
+  itemize amazon -account wife -dry-run -days 14 -max 1
+`)
 }
 
 // ToSyncOptions converts SyncFlags to sync.Options

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -122,6 +122,25 @@ func ResolveAmazonAccount(cfg *config.Config, flagAccount string, extraArgs []st
 	return "", nil
 }
 
+// ResolveAmazonSetupAccount requires the account being created to be explicit.
+// Setup must not silently reuse an environment or config default because doing
+// so could overwrite a different account's persistent browser profile.
+func ResolveAmazonSetupAccount(flagAccount string, extraArgs []string) (string, error) {
+	if len(extraArgs) > 1 {
+		return "", fmt.Errorf("unexpected arguments: %s; use -account %s", strings.Join(extraArgs, " "), extraArgs[0])
+	}
+	if len(extraArgs) == 1 {
+		if flagAccount != "" {
+			return "", fmt.Errorf("use either -account or a positional account, not both")
+		}
+		return extraArgs[0], nil
+	}
+	if flagAccount == "" {
+		return "", fmt.Errorf("amazon setup requires -account <name>")
+	}
+	return flagAccount, nil
+}
+
 // ListAmazonAccounts returns the names of saved amazon-go cookie accounts found
 // under ~/.amazon-go (files named cookies-<account>.json).
 func ListAmazonAccounts(cfg *config.Config) ([]string, error) {

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -55,6 +55,24 @@ func TestResolveAmazonAccount_RejectsUnexpectedExtraArgs(t *testing.T) {
 	assert.Contains(t, err.Error(), "-account amazon-wife")
 }
 
+func TestResolveAmazonSetupAccount_RequiresExplicitAccount(t *testing.T) {
+	account, err := ResolveAmazonSetupAccount("", nil)
+
+	require.Error(t, err)
+	assert.Empty(t, account)
+	assert.Contains(t, err.Error(), "requires -account")
+}
+
+func TestResolveAmazonSetupAccount_AcceptsFlagOrPositionalName(t *testing.T) {
+	account, err := ResolveAmazonSetupAccount("wife", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "wife", account)
+
+	account, err = ResolveAmazonSetupAccount("", []string{"wife"})
+	require.NoError(t, err)
+	assert.Equal(t, "wife", account)
+}
+
 func TestResolveAmazonAccount_FlagBeatsConfig(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Providers.Amazon.AccountName = "from-config"


### PR DESCRIPTION
## Summary

- add a first-class `itemize amazon setup -account <name>` login flow
- create and secure the persistent Chromium profile automatically
- lead Amazon help with setup and move low-level authentication flags into an advanced section
- point missing or expired accounts to the guided setup command
- require an explicit setup account to avoid overwriting configured defaults
- document setup and add focused regression coverage

## Validation

- `go test ./...`
- `go test ./... -race`
- `golangci-lint run --timeout=5m`
- `go vet ./...`
- Amazon dry run (expected authentication failure after saved profiles were intentionally removed; confirmed new setup guidance)
- independent lightweight review completed with no remaining findings