### PR TITLE
fix: harden Walmart detail fetching

### DIFF
--- a/docs/bug-fixes.md
+++ b/docs/bug-fixes.md
@@ -12,6 +12,36 @@ Each bug fix entry should include:
 
 ## Bug Fixes
 
+### 2026-07-15: Walmart detail requests were rejected with HTTP 456
+
+**Description:**
+Walmart purchase history succeeded, but itemize then sent an obsolete request profile for every order-detail lookup. Walmart rejected those calls with HTTP 456, and itemize continued through the remaining history, repeating a session-level failure for orders it would later discard because of `-max`.
+
+**Test Case:**
+```go
+// internal/adapters/providers/walmart/provider_test.go:
+// TestProvider_FetchOrders_WithMaxOrders
+// Expected: -max truncates summaries before any detail requests.
+
+// TestProvider_FetchOrders_PassesPurchaseHistoryGroupID
+// Expected: the summary groupId is forwarded to getOrder.
+
+// TestProvider_FetchOrders_StopsOnBotChallenge
+// Expected: ErrBotChallenge stops the detail loop after one request.
+```
+
+**Root Cause:**
+Itemize used `walmart-client-go/v2 v2.1.0`, whose `getOrder` hash, GraphQL variables, user agent, Walmart platform version, and tracing headers no longer matched the web client. Cookie refresh merged snapshots, so expired WAF cookies could also survive. The itemize provider ignored each HTTP 456 as an order-specific failure, did not pass the purchase-history `groupId`, and applied `MaxOrders` only after fetching every detail response.
+
+**Fix Applied:**
+Upgraded to `walmart-client-go/v2 v2.2.1`, which captures the live browser request profile, replaces stale cookie snapshots, preserves response-cookie path scope, forwards group IDs, and exposes `ErrBotChallenge`. Itemize now removes active/unfinalized summaries and truncates the remaining deduplicated summaries before detail calls, calls `GetOrderWithGroup`, and returns immediately when Walmart challenges the browser session.
+
+**Verification:**
+- The four regression tests failed before their fixes and pass after them.
+- The walmart client performed a live read-only `getOrder` with the captured order/group ID and returned 17 items.
+- A second live client sequence fetched purchase history and then a completed in-store order with 4 items, confirming path-scoped history cookies no longer poison detail requests.
+- `./itemize walmart -dry-run -days 14 -max 1 -verbose` skipped the active `PLACED` summary, issued exactly one completed-order detail request, exited successfully, and logged no HTTP 456 response.
+
 ### 2026-07-10: Walmart refunds lacked item-level categorization
 
 **Description:**

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/eshaffer321/amazon-go v0.3.0
 	github.com/eshaffer321/costco-go v0.3.11
 	github.com/eshaffer321/monarch-go/v2 v2.0.0
-	github.com/eshaffer321/walmart-client-go/v2 v2.1.0
+	github.com/eshaffer321/walmart-client-go/v2 v2.2.1
 	github.com/getsentry/sentry-go v0.36.0
 	github.com/go-chi/chi/v5 v5.3.0
 	github.com/pressly/goose/v3 v3.27.2

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/eshaffer321/costco-go v0.3.11 h1:vOEXcSj/vGlwE/4AbXK3uUdXG7XYg1qfUPVi
 github.com/eshaffer321/costco-go v0.3.11/go.mod h1:ANJTHfRSPyot9cWKNlfs5qDKRKkA4tYORrorvWx/vbM=
 github.com/eshaffer321/monarch-go/v2 v2.0.0 h1:3reQ15D0K/Btc3mu+sfWdKJnU0hmNb0/ZwsbVUjN4l8=
 github.com/eshaffer321/monarch-go/v2 v2.0.0/go.mod h1:0rdAjSetvYQ8wGkUdg4BsqN8jTMhJ4TbHAr6qhAzSk4=
-github.com/eshaffer321/walmart-client-go/v2 v2.1.0 h1:FbOL/CuTXaTVDLgcBtE5C0SvjkwO6d/cIqNAVAF1OvU=
-github.com/eshaffer321/walmart-client-go/v2 v2.1.0/go.mod h1:4PVK9TsqFscTZypC67dgCt/vnPxXdtaheJVM7HOnod0=
+github.com/eshaffer321/walmart-client-go/v2 v2.2.1 h1:FT6VAzEC6SNdQm7r2Mr26Q8/cREDj5vlTGBHVp2W1lw=
+github.com/eshaffer321/walmart-client-go/v2 v2.2.1/go.mod h1:4PVK9TsqFscTZypC67dgCt/vnPxXdtaheJVM7HOnod0=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/getsentry/sentry-go v0.36.0 h1:UkCk0zV28PiGf+2YIONSSYiYhxwlERE5Li3JPpZqEns=

--- a/internal/adapters/providers/walmart/order.go
+++ b/internal/adapters/providers/walmart/order.go
@@ -13,7 +13,7 @@ import (
 // Order wraps a Walmart order and implements providers.Order interface
 type Order struct {
 	walmartOrder *walmartclient.Order
-	client       *walmartclient.WalmartClient
+	client       walmartLedgerClient
 	logger       *slog.Logger
 	ctx          context.Context
 

--- a/internal/adapters/providers/walmart/provider.go
+++ b/internal/adapters/providers/walmart/provider.go
@@ -2,6 +2,7 @@ package walmart
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -10,9 +11,19 @@ import (
 	walmartclient "github.com/eshaffer321/walmart-client-go/v2"
 )
 
+type walmartLedgerClient interface {
+	GetOrderLedger(context.Context, string) (*walmartclient.OrderLedger, error)
+}
+
+type walmartAPI interface {
+	walmartLedgerClient
+	GetPurchaseHistory(context.Context, walmartclient.PurchaseHistoryRequest) (*walmartclient.PurchaseHistoryResponse, error)
+	GetOrderWithGroup(context.Context, string, string, bool) (*walmartclient.Order, error)
+}
+
 // Provider implements the OrderProvider interface for Walmart
 type Provider struct {
-	client    *walmartclient.WalmartClient
+	client    walmartAPI
 	logger    *slog.Logger
 	rateLimit time.Duration
 }
@@ -20,6 +31,13 @@ type Provider struct {
 // NewProvider creates a new Walmart provider
 // Note: Caller is responsible for adding any scoping attributes (e.g., system="walmart")
 func NewProvider(client *walmartclient.WalmartClient, logger *slog.Logger) *Provider {
+	if client == nil {
+		return newProvider(nil, logger)
+	}
+	return newProvider(client, logger)
+}
+
+func newProvider(client walmartAPI, logger *slog.Logger) *Provider {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -69,6 +87,19 @@ func (p *Provider) FetchOrders(ctx context.Context, opts providers.FetchOptions)
 		p.logger.Warn("duplicate order summary returned by Walmart; using first occurrence",
 			slog.String("order_id", orderID))
 	}
+	completedSummaries := make([]walmartclient.OrderSummary, 0, len(orderSummaries))
+	for _, summary := range orderSummaries {
+		if summary.IsActive {
+			p.logger.Debug("skipping active Walmart order before detail fetch",
+				slog.String("order_id", summary.OrderID))
+			continue
+		}
+		completedSummaries = append(completedSummaries, summary)
+	}
+	orderSummaries = completedSummaries
+	if opts.MaxOrders > 0 && len(orderSummaries) > opts.MaxOrders {
+		orderSummaries = orderSummaries[:opts.MaxOrders]
+	}
 
 	// Convert OrderSummary to full Orders
 	var providerOrders []providers.Order
@@ -78,47 +109,25 @@ func (p *Provider) FetchOrders(ctx context.Context, opts providers.FetchOptions)
 			return providerOrders, fmt.Errorf("cancelled during order fetch: %w", err)
 		}
 
-		// Fetch full order details if requested
-		if opts.IncludeDetails {
-			isInStore := summary.FulfillmentType == "IN_STORE"
-			fullOrder, err := p.client.GetOrder(ctx, summary.OrderID, isInStore)
-			if err != nil {
-				p.logger.Warn("failed to fetch order details, skipping",
-					slog.String("order_id", summary.OrderID),
-					slog.String("error", err.Error()))
-				continue
+		// The domain order requires details even when IncludeDetails is false.
+		isInStore := summary.FulfillmentType == "IN_STORE"
+		fullOrder, err := p.client.GetOrderWithGroup(ctx, summary.OrderID, summary.GroupID, isInStore)
+		if err != nil {
+			if errors.Is(err, walmartclient.ErrBotChallenge) {
+				return providerOrders, fmt.Errorf("walmart session rejected while fetching order details: %w", err)
 			}
-
-			providerOrders = append(providerOrders, &Order{
-				walmartOrder: fullOrder,
-				client:       p.client,
-				logger:       p.logger,
-				ctx:          ctx,
-			})
-		} else {
-			// For basic listing, we'd need to create a minimal Order
-			// For now, always fetch details
-			isInStore := summary.FulfillmentType == "IN_STORE"
-			fullOrder, err := p.client.GetOrder(ctx, summary.OrderID, isInStore)
-			if err != nil {
-				p.logger.Warn("failed to fetch order details, skipping",
-					slog.String("order_id", summary.OrderID),
-					slog.String("error", err.Error()))
-				continue
-			}
-
-			providerOrders = append(providerOrders, &Order{
-				walmartOrder: fullOrder,
-				client:       p.client,
-				logger:       p.logger,
-				ctx:          ctx,
-			})
+			p.logger.Warn("failed to fetch order details, skipping",
+				slog.String("order_id", summary.OrderID),
+				slog.String("error", err.Error()))
+			continue
 		}
-	}
 
-	// Apply max orders limit if specified
-	if opts.MaxOrders > 0 && len(providerOrders) > opts.MaxOrders {
-		providerOrders = providerOrders[:opts.MaxOrders]
+		providerOrders = append(providerOrders, &Order{
+			walmartOrder: fullOrder,
+			client:       p.client,
+			logger:       p.logger,
+			ctx:          ctx,
+		})
 	}
 
 	p.logger.Info("fetched orders", slog.Int("total", len(providerOrders)))

--- a/internal/adapters/providers/walmart/provider_test.go
+++ b/internal/adapters/providers/walmart/provider_test.go
@@ -2,6 +2,7 @@ package walmart
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"testing"
@@ -12,6 +13,40 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type detailCall struct {
+	orderID   string
+	groupID   string
+	isInStore bool
+}
+
+type fakeWalmartClient struct {
+	summaries   []walmartclient.OrderSummary
+	historyErr  error
+	detailErr   error
+	detailCalls []detailCall
+}
+
+func (f *fakeWalmartClient) GetPurchaseHistory(_ context.Context, _ walmartclient.PurchaseHistoryRequest) (*walmartclient.PurchaseHistoryResponse, error) {
+	if f.historyErr != nil {
+		return nil, f.historyErr
+	}
+	resp := &walmartclient.PurchaseHistoryResponse{}
+	resp.Data.OrderHistoryV2.OrderGroups = f.summaries
+	return resp, nil
+}
+
+func (f *fakeWalmartClient) GetOrderWithGroup(_ context.Context, orderID, groupID string, isInStore bool) (*walmartclient.Order, error) {
+	f.detailCalls = append(f.detailCalls, detailCall{orderID: orderID, groupID: groupID, isInStore: isInStore})
+	if f.detailErr != nil {
+		return nil, f.detailErr
+	}
+	return &walmartclient.Order{ID: orderID}, nil
+}
+
+func (f *fakeWalmartClient) GetOrderLedger(_ context.Context, orderID string) (*walmartclient.OrderLedger, error) {
+	return &walmartclient.OrderLedger{OrderID: orderID}, nil
+}
 
 // TestProvider_ImplementsInterface verifies Provider implements OrderProvider
 func TestProvider_ImplementsInterface(t *testing.T) {
@@ -41,11 +76,8 @@ func TestProvider_SupportsFeatures(t *testing.T) {
 
 // TestProvider_FetchOrders_EmptyResult tests fetching with no orders
 func TestProvider_FetchOrders_EmptyResult(t *testing.T) {
-	// This test will fail until we implement the provider
-	t.Skip("Skipping until we have a mock walmart client")
-
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
-	provider := NewProvider(nil, logger)
+	provider := newProvider(&fakeWalmartClient{}, logger)
 
 	ctx := context.Background()
 	opts := providers.FetchOptions{
@@ -63,10 +95,84 @@ func TestProvider_FetchOrders_EmptyResult(t *testing.T) {
 
 // TestProvider_FetchOrders_WithMaxOrders tests max orders limit
 func TestProvider_FetchOrders_WithMaxOrders(t *testing.T) {
-	t.Skip("Skipping until we have a mock walmart client")
+	client := &fakeWalmartClient{summaries: []walmartclient.OrderSummary{
+		{OrderID: "order-1", GroupID: "group-1", FulfillmentType: "IN_STORE"},
+		{OrderID: "order-2", GroupID: "group-2", FulfillmentType: "DFS"},
+		{OrderID: "order-3", GroupID: "group-3", FulfillmentType: "IN_STORE"},
+	}}
+	provider := newProvider(client, nil)
 
-	// TODO: Create mock client that returns multiple orders
-	// Then verify MaxOrders limits the result
+	orders, err := provider.FetchOrders(context.Background(), providers.FetchOptions{
+		StartDate:      time.Now().AddDate(0, 0, -7),
+		EndDate:        time.Now(),
+		MaxOrders:      2,
+		IncludeDetails: true,
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, orders, 2)
+	assert.Equal(t, []detailCall{
+		{orderID: "order-1", groupID: "group-1", isInStore: true},
+		{orderID: "order-2", groupID: "group-2", isInStore: false},
+	}, client.detailCalls, "max orders must be applied before detail requests")
+}
+
+func TestProvider_FetchOrders_SkipsActiveOrdersBeforeMax(t *testing.T) {
+	client := &fakeWalmartClient{summaries: []walmartclient.OrderSummary{
+		{OrderID: "active-order", GroupID: "active-group", IsActive: true},
+		{OrderID: "completed-order", GroupID: "completed-group", IsActive: false},
+	}}
+	provider := newProvider(client, nil)
+
+	orders, err := provider.FetchOrders(context.Background(), providers.FetchOptions{
+		StartDate: time.Now().AddDate(0, 0, -7),
+		EndDate:   time.Now(),
+		MaxOrders: 1,
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, orders, 1)
+	assert.Equal(t, []detailCall{
+		{orderID: "completed-order", groupID: "completed-group", isInStore: false},
+	}, client.detailCalls, "active orders must not consume detail requests or the max-orders budget")
+}
+
+func TestProvider_FetchOrders_PassesPurchaseHistoryGroupID(t *testing.T) {
+	client := &fakeWalmartClient{summaries: []walmartclient.OrderSummary{
+		{OrderID: "order-1", GroupID: "captured-group", FulfillmentType: "IN_STORE"},
+	}}
+	provider := newProvider(client, nil)
+
+	_, err := provider.FetchOrders(context.Background(), providers.FetchOptions{
+		StartDate: time.Now().AddDate(0, 0, -7),
+		EndDate:   time.Now(),
+	})
+
+	require.NoError(t, err)
+	require.Len(t, client.detailCalls, 1)
+	assert.Equal(t, "captured-group", client.detailCalls[0].groupID)
+}
+
+func TestProvider_FetchOrders_StopsOnBotChallenge(t *testing.T) {
+	challenge := fmt.Errorf("wrapped challenge: %w", walmartclient.ErrBotChallenge)
+	client := &fakeWalmartClient{
+		summaries: []walmartclient.OrderSummary{
+			{OrderID: "order-1", GroupID: "group-1"},
+			{OrderID: "order-2", GroupID: "group-2"},
+		},
+		detailErr: challenge,
+	}
+	provider := newProvider(client, nil)
+
+	orders, err := provider.FetchOrders(context.Background(), providers.FetchOptions{
+		StartDate: time.Now().AddDate(0, 0, -7),
+		EndDate:   time.Now(),
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, walmartclient.ErrBotChallenge)
+	assert.Empty(t, orders)
+	assert.Len(t, client.detailCalls, 1, "bot challenge must stop further detail requests")
 }
 
 func TestDedupeOrderSummariesByID(t *testing.T) {


### PR DESCRIPTION
## What

- upgrade walmart-client-go from v2.1.0 to v2.2.1
- pass purchase-history group IDs into order-detail requests
- skip active and unfinalized Walmart summaries before detail fetching
- apply -max before detail network calls
- stop immediately when Walmart returns ErrBotChallenge
- replace skipped provider tests with a fake client and regression coverage
- document the root cause and live verification

## Why

Itemize could fetch purchase history but replayed an obsolete request profile for getOrder. It also flattened path-scoped response cookies, omitted group IDs, requested active PLACED orders, applied -max only after all details, and continued after session-level HTTP 456 responses.

## Verification

- CI-pinned golangci-lint v2.4.0: 0 issues
- go vet ./...
- go test -race -timeout 30s ./...
- go build -o itemize ./cmd/itemize
- pre-commit hook passed
- live isolated ./itemize walmart -dry-run -days 14 -max 1 -verbose: active PLACED summary skipped, exactly one completed detail request, successful exit, zero HTTP 456 responses
- underlying client live checks: captured delivery order returned 17 items; purchase history followed by in-store detail returned 4 items